### PR TITLE
refactor: single product fetch and category extraction

### DIFF
--- a/src/app/modules/public/ver-productos/ver-productos.component.spec.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.spec.ts
@@ -1,16 +1,39 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { VerProductosComponent } from './ver-productos.component';
+import { ProductoService } from '../../../core/services/producto.service';
+import { Producto } from '../../../shared/models/producto.model';
+import { UserService } from '../../../core/services/user.service';
+import { ModalService } from '../../../core/services/modal.service';
+import { Router } from '@angular/router';
+import { CartService } from '../../../core/services/cart.service';
 
 describe('VerProductosComponent', () => {
   let component: VerProductosComponent;
   let fixture: ComponentFixture<VerProductosComponent>;
+  let productoService: Partial<ProductoService>;
 
   beforeEach(async () => {
+    const productosMock: Producto[] = [
+      { productoId: 1, nombre: 'Coca Cola', precio: 10, cantidad: 1, categoria: 'Bebidas', subcategoria: 'Gaseosas' },
+      { productoId: 2, nombre: 'Ensalada', precio: 15, cantidad: 1, categoria: 'Comidas', subcategoria: 'Entradas' }
+    ];
+
+    productoService = {
+      getProductos: jest.fn().mockReturnValue(of({ data: productosMock, message: '' }))
+    } as Partial<ProductoService>;
+
     await TestBed.configureTestingModule({
-      imports: [VerProductosComponent]
-    })
-    .compileComponents();
+      imports: [VerProductosComponent],
+      providers: [
+        { provide: ProductoService, useValue: productoService },
+        { provide: UserService, useValue: { getAuthState: () => of(false), getUserRole: () => null } },
+        { provide: ModalService, useValue: {} },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: CartService, useValue: { addToCart: jest.fn() } }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(VerProductosComponent);
     component = fixture.componentInstance;
@@ -19,5 +42,10 @@ describe('VerProductosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load categories and subcategories', () => {
+    expect(component.categorias).toEqual(['Bebidas', 'Comidas']);
+    expect(component.subcategorias).toEqual(['Gaseosas', 'Entradas']);
   });
 });

--- a/src/app/modules/public/ver-productos/ver-productos.component.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.ts
@@ -42,32 +42,27 @@ export class VerProductosComponent implements OnInit {
 
 
   obtenerProductos(): void {
-    this.productoService.getProductos({ onlyActive: true, includeImage: true }).subscribe(response => {
-      if (response.data) {
-        this.productos = response.data;
-      } else {
-        this.mensaje = response.message;
-      }
-    });
-    this.productoService.getProductos({ onlyActive: true, includeImage: true }).subscribe(response => {
-      if (response.data) {
-        this.productos = response.data;
+    this.productoService
+      .getProductos({ onlyActive: true, includeImage: true })
+      .subscribe(response => {
+        if (response.data) {
+          this.productos = response.data;
 
-        // Extraer categorías únicas
-        const categoriasSet = new Set<string>();
-        const subcategoriasSet = new Set<string>();
+          // Extraer categorías y subcategorías únicas
+          const categoriasSet = new Set<string>();
+          const subcategoriasSet = new Set<string>();
 
-        this.productos.forEach(p => {
-          if (p.categoria) categoriasSet.add(p.categoria);
-          if (p.subcategoria) subcategoriasSet.add(p.subcategoria);
-        });
+          this.productos.forEach(p => {
+            if (p.categoria) categoriasSet.add(p.categoria);
+            if (p.subcategoria) subcategoriasSet.add(p.subcategoria);
+          });
 
-        this.categorias = Array.from(categoriasSet);
-        this.subcategorias = Array.from(subcategoriasSet);
-      } else {
-        this.mensaje = response.message;
-      }
-    });
+          this.categorias = Array.from(categoriasSet);
+          this.subcategorias = Array.from(subcategoriasSet);
+        } else {
+          this.mensaje = response.message;
+        }
+      });
   }
   actualizarSubcategorias(): void {
     const set = new Set<string>();


### PR DESCRIPTION
## Summary
- fetch products once and derive categories and subcategories in the response
- add unit test ensuring categories and subcategories populate correctly

## Testing
- `npm test` *(fails: Test Suites: 16 failed, 25 passed)*
- `npx jest src/app/modules/public/ver-productos/ver-productos.component.spec.ts`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ca9fec8832593bd3aa0fd090333