### PR TITLE
Simplifica conteo de filtros de domicilios

### DIFF
--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.html
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.html
@@ -21,19 +21,22 @@
         </div>
 
         <div class="row mt-3 align-items-center">
-            <div [ngClass]="{'col-12': soloUnFiltro(), 'col-md-6': dosFiltros(), 'col-md-4': tresFiltros()}"
+            <div
+                [ngClass]="{'col-12': countFiltros() === 1, 'col-md-6': countFiltros() === 2, 'col-md-4': countFiltros() === 3}"
                 *ngIf="buscarPorDireccion">
                 <input type="text" id="direccion" class="form-control" [(ngModel)]="direccion"
                     placeholder="Ej: Calle 50 #20-30" />
             </div>
 
-            <div [ngClass]="{'col-12': soloUnFiltro(), 'col-md-6': dosFiltros(), 'col-md-4': tresFiltros()}"
+            <div
+                [ngClass]="{'col-12': countFiltros() === 1, 'col-md-6': countFiltros() === 2, 'col-md-4': countFiltros() === 3}"
                 *ngIf="buscarPorTelefono">
                 <input type="text" id="telefono" class="form-control" [(ngModel)]="telefono"
                     placeholder="Ej: 3042449339" />
             </div>
 
-            <div [ngClass]="{'col-12': soloUnFiltro(), 'col-md-6': dosFiltros(), 'col-md-4': tresFiltros()}"
+            <div
+                [ngClass]="{'col-12': countFiltros() === 1, 'col-md-6': countFiltros() === 2, 'col-md-4': countFiltros() === 3}"
                 *ngIf="buscarPorFecha">
                 <input type="date" id="fechaDomicilio" class="form-control" [(ngModel)]="fechaDomicilio" />
             </div>

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.spec.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.spec.ts
@@ -1,5 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { DomicilioService } from '../../../../core/services/domicilio.service';
+import { UserService } from '../../../../core/services/user.service';
+import { TrabajadorService } from '../../../../core/services/trabajador.service';
+import { ModalService } from '../../../../core/services/modal.service';
 import { ConsultarDomicilioComponent } from './consultar-domicilios.component';
 
 describe('ConsultarDomiciliosComponent', () => {
@@ -8,9 +12,14 @@ describe('ConsultarDomiciliosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ConsultarDomicilioComponent]
-    })
-    .compileComponents();
+      imports: [ConsultarDomicilioComponent],
+      providers: [
+        { provide: DomicilioService, useValue: {} },
+        { provide: UserService, useValue: { getUserId: () => {} } },
+        { provide: TrabajadorService, useValue: {} },
+        { provide: ModalService, useValue: {} }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ConsultarDomicilioComponent);
     component = fixture.componentInstance;
@@ -19,5 +28,29 @@ describe('ConsultarDomiciliosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should return 1 when one filter is active', () => {
+    component.buscarPorDireccion = true;
+    component.buscarPorTelefono = false;
+    component.buscarPorFecha = false;
+
+    expect(component.countFiltros()).toBe(1);
+  });
+
+  it('should return 2 when two filters are active', () => {
+    component.buscarPorDireccion = true;
+    component.buscarPorTelefono = true;
+    component.buscarPorFecha = false;
+
+    expect(component.countFiltros()).toBe(2);
+  });
+
+  it('should return 3 when all filters are active', () => {
+    component.buscarPorDireccion = true;
+    component.buscarPorTelefono = true;
+    component.buscarPorFecha = true;
+
+    expect(component.countFiltros()).toBe(3);
   });
 });

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
@@ -117,16 +117,12 @@ export class ConsultarDomicilioComponent implements OnInit {
       });
   }
 
-  soloUnFiltro(): boolean {
-    return [this.buscarPorDireccion, this.buscarPorTelefono, this.buscarPorFecha].filter(Boolean).length === 1;
-  }
-
-  dosFiltros(): boolean {
-    return [this.buscarPorDireccion, this.buscarPorTelefono, this.buscarPorFecha].filter(Boolean).length === 2;
-  }
-
-  tresFiltros(): boolean {
-    return [this.buscarPorDireccion, this.buscarPorTelefono, this.buscarPorFecha].filter(Boolean).length === 3;
+  countFiltros(): number {
+    return [
+      this.buscarPorDireccion,
+      this.buscarPorTelefono,
+      this.buscarPorFecha
+    ].filter(Boolean).length;
   }
   marcarEntregado(domicilio: Domicilio): void {
     this.domicilioService.updateDomicilio(domicilio.domicilioId!, { entregado: true }).subscribe(response => {


### PR DESCRIPTION
## Summary
- reemplaza métodos de filtro individuales por `countFiltros`
- actualiza plantilla para calcular ancho de columnas según número de filtros
- añade pruebas unitarias para 1, 2 y 3 filtros activos

## Testing
- `npm test` *(fails: 15 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f979f66388325af5801959f3fc0c9