### PR TITLE
test: cover core services

### DIFF
--- a/src/app/core/services/cart.service.spec.ts
+++ b/src/app/core/services/cart.service.spec.ts
@@ -1,16 +1,127 @@
 import { TestBed } from '@angular/core/testing';
-
+import { PLATFORM_ID } from '@angular/core';
 import { CartService } from './cart.service';
+import { Producto } from '../../shared/models/producto.model';
+
+const STORAGE_KEY = 'carrito';
+const LAST_KEY = `${STORAGE_KEY}-lastClear`;
+
+function createProduct(id: number): Producto {
+  return { productoId: id, nombre: `P${id}`, precio: 10 } as any;
+}
 
 describe('CartService', () => {
-  let service: CartService;
+  let store: Record<string, string>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(CartService);
+    store = {};
+    const mockLS = {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+      clear: () => { store = {}; }
+    };
+    Object.defineProperty(window, 'localStorage', { value: mockLS, writable: true });
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  function init(platform: 'browser' | 'server' = 'browser'): CartService {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [{ provide: PLATFORM_ID, useValue: platform }]
+    });
+    return TestBed.inject(CartService);
+  }
+
+  it('clears old cart on init', () => {
+    store[STORAGE_KEY] = JSON.stringify([createProduct(1)]);
+    store[LAST_KEY] = '2000-01-01';
+    const today = new Date().toISOString().split('T')[0];
+    const service = init();
+    expect(store[STORAGE_KEY]).toBeUndefined();
+    expect(store[LAST_KEY]).toBe(today);
+    expect(service.count$.value).toBe(0);
+  });
+
+  it('loads existing cart when date is today', () => {
+    const prod = createProduct(2);
+    store[STORAGE_KEY] = JSON.stringify([prod]);
+    const today = new Date().toISOString().split('T')[0];
+    store[LAST_KEY] = today;
+    const service = init();
+    expect(service.getItems().length).toBe(1);
+    expect(service.count$.value).toBe(1);
+  });
+
+  it('adds products and increases quantity', () => {
+    const service = init();
+    const prod = createProduct(3);
+    service.addToCart(prod);
+    expect(service.count$.value).toBe(1);
+    service.addToCart(prod);
+    expect(service.getItems()[0].cantidad).toBe(2);
+    expect(service.count$.value).toBe(2);
+  });
+
+  it('changes quantity and removes when zero', () => {
+    const service = init();
+    const prod = createProduct(4);
+    service.addToCart(prod);
+    service.changeQty(4, 2);
+    expect(service.getItems()[0].cantidad).toBe(3);
+    service.changeQty(4, -3);
+    expect(service.getItems().length).toBe(0);
+    expect(service.count$.value).toBe(0);
+  });
+
+  it('removes a product', () => {
+    const service = init();
+    const p1 = createProduct(5);
+    const p2 = createProduct(6);
+    service.addToCart(p1);
+    service.addToCart(p2);
+    service.remove(5);
+    expect(service.getItems().length).toBe(1);
+    expect(service.getItems()[0].productoId).toBe(6);
+  });
+
+  it('clears cart manually', () => {
+    const service = init();
+    service.addToCart(createProduct(7));
+    service.clearCart();
+    expect(store[STORAGE_KEY]).toBeUndefined();
+    expect(store[LAST_KEY]).toBeUndefined();
+    expect(service.count$.value).toBe(0);
+  });
+
+  it('handles non-browser platform', () => {
+    const service = init('server');
+    (service as any).clearIfNeeded();
+    (service as any).loadCart();
+    service.addToCart(createProduct(8));
+    expect(service.getItems().length).toBe(0);
+    (service as any).saveCart([createProduct(9)]);
+    expect(service.getItems().length).toBe(0);
+    service.changeQty(8, 1);
+    service.remove(8);
+    service.clearCart();
+    expect(service.count$.value).toBe(0);
+  });
+
+  it('handles items without quantity', () => {
+    const service = init();
+    (service as any).saveCart([{ productoId: 10 } as any, { productoId: 11, cantidad: 2 } as any]);
+    expect(service.count$.value).toBe(3);
+    service.addToCart({ productoId: 10 } as any);
+    expect(service.getItems().find(p => p.productoId === 10)?.cantidad).toBe(2);
+    (service as any).saveCart([{ productoId: 12 } as any, { productoId: 13, cantidad: 1 } as any]);
+    service.changeQty(12, 1);
+    expect(service.getItems().find(p => p.productoId === 12)?.cantidad).toBe(2);
+  });
+
+  it('loads empty cart when storage missing', () => {
+    const service = init();
+    store = {};
+    (service as any).loadCart();
+    expect(service.count$.value).toBe(0);
   });
 });

--- a/src/app/core/services/metodos-pago.service.spec.ts
+++ b/src/app/core/services/metodos-pago.service.spec.ts
@@ -1,19 +1,38 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { MetodosPagoService } from './metodos-pago.service';
+import { environment } from '../../../environments/environment';
 
 describe('MetodosPagoService', () => {
   let service: MetodosPagoService;
+  let http: HttpTestingController;
+  const baseUrl = `${environment.apiUrl}/metodos_pago`;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
     service = TestBed.inject(MetodosPagoService);
+    http = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => http.verify());
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('gets all methods', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.getAll().subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('gets method by id', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.getById(5).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/search?id=5`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
   });
 });

--- a/src/app/core/services/pedido-cliente.service.spec.ts
+++ b/src/app/core/services/pedido-cliente.service.spec.ts
@@ -1,19 +1,40 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { PedidoClienteService } from './pedido-cliente.service';
+import { environment } from '../../../environments/environment';
 
 describe('PedidoClienteService', () => {
   let service: PedidoClienteService;
+  let http: HttpTestingController;
+  const baseUrl = `${environment.apiUrl}/pedido_clientes`;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
     service = TestBed.inject(PedidoClienteService);
+    http = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => http.verify());
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('creates relation', () => {
+    const payload = { pedidoId: 1, clienteId: 2 } as any;
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.create(payload).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+    req.flush(mock);
+  });
+
+  it('gets pedido cliente', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.getPedidoCliente(3, 4).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/3/4`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
   });
 });

--- a/src/app/core/services/pedido.service.spec.ts
+++ b/src/app/core/services/pedido.service.spec.ts
@@ -1,19 +1,65 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { PedidoService } from './pedido.service';
+import { environment } from '../../../environments/environment';
 
 describe('PedidoService', () => {
   let service: PedidoService;
+  let http: HttpTestingController;
+  const baseUrl = `${environment.apiUrl}/pedidos`;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
     service = TestBed.inject(PedidoService);
+    http = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => http.verify());
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('creates pedido', () => {
+    const pedido = { total: 100 } as any;
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.createPedido(pedido).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(pedido);
+    req.flush(mock);
+  });
+
+  it('assigns pago', () => {
+    const mock = { code: 200, message: 'ok' };
+    service.assignPago(1, 2).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/asignar-pago?pedido_id=1&pago_id=2`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toBeNull();
+    req.flush(mock);
+  });
+
+  it('assigns domicilio', () => {
+    const mock = { code: 200, message: 'ok' };
+    service.assignDomicilio(1, 3).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/asignar-domicilio?pedido_id=1&domicilio_id=3`);
+    expect(req.request.method).toBe('POST');
+    req.flush(mock);
+  });
+
+  it('gets mis pedidos', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.getMisPedidos(5).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?cliente=5`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('gets pedido detalles', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.getPedidoDetalles(7).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/detalles?pedido_id=7`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
   });
 });

--- a/src/app/core/services/producto-pedido.service.spec.ts
+++ b/src/app/core/services/producto-pedido.service.spec.ts
@@ -1,19 +1,40 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ProductoPedidoService } from './producto-pedido.service';
+import { environment } from '../../../environments/environment';
 
 describe('ProductoPedidoService', () => {
   let service: ProductoPedidoService;
+  let http: HttpTestingController;
+  const baseUrl = `${environment.apiUrl}/producto_pedido`;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
     service = TestBed.inject(ProductoPedidoService);
+    http = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => http.verify());
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('creates producto pedido', () => {
+    const payload: any = {
+      PK_ID_PEDIDO: 1,
+      DETALLES_PRODUCTOS: [
+        { PK_ID_PRODUCTO: 1, NOMBRE: 'A', CANTIDAD: 1, PRECIO_UNITARIO: 10, SUBTOTAL: 10 }
+      ]
+    };
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.create(payload).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      PK_ID_PEDIDO: 1,
+      DETALLES_PRODUCTOS: JSON.stringify(payload.DETALLES_PRODUCTOS)
+    });
+    req.flush(mock);
   });
 });

--- a/src/app/core/services/producto.service.spec.ts
+++ b/src/app/core/services/producto.service.spec.ts
@@ -1,19 +1,59 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ProductoService } from './producto.service';
+import { environment } from '../../../environments/environment';
 
 describe('ProductoService', () => {
   let service: ProductoService;
+  let http: HttpTestingController;
+  const baseUrl = `${environment.apiUrl}/productos`;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
-    });
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
     service = TestBed.inject(ProductoService);
+    http = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => http.verify());
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('gets productos', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.getProductos({ categoria: '1' }).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?categoria=1`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('creates producto', () => {
+    const form = new FormData();
+    form.append('nombre', 'test');
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.createProducto(form).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toBe(form);
+    req.flush(mock);
+  });
+
+  it('gets producto by id', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.getProductoById(2).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/search?id=2`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('updates producto', () => {
+    const form = new FormData();
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.updateProducto(3, form).subscribe(res => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=3`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toBe(form);
+    req.flush(mock);
   });
 });


### PR DESCRIPTION
## Summary
- add comprehensive CartService tests covering browser and server flows
- test API methods for payment, order, and product services

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdb52d68883258c50f2af04378660