### PR TITLE
test: cover shared mocks

### DIFF
--- a/src/app/shared/mocks/fakeDomSanitizer.spec.ts
+++ b/src/app/shared/mocks/fakeDomSanitizer.spec.ts
@@ -1,0 +1,44 @@
+import { FakeDomSanitizer } from './fakeDomSanitizer';
+
+describe('FakeDomSanitizer', () => {
+  let sanitizer: FakeDomSanitizer;
+
+  beforeEach(() => {
+    sanitizer = new FakeDomSanitizer();
+  });
+
+  it('bypassSecurityTrustResourceUrl should wrap URL', () => {
+    const url = 'http://example.com';
+    const result = sanitizer.bypassSecurityTrustResourceUrl(url);
+    expect(result.toString()).toBe(url);
+  });
+
+  it('sanitize should return null when value is falsy', () => {
+    expect(sanitizer.sanitize(0, null)).toBeNull();
+  });
+
+  it('sanitize should return string representation', () => {
+    const value = 'test';
+    expect(sanitizer.sanitize(0, value)).toBe(value);
+  });
+
+  it('bypassSecurityTrustHtml should return provided value', () => {
+    const value = '<div>safe</div>';
+    expect(sanitizer.bypassSecurityTrustHtml(value)).toBe(value as any);
+  });
+
+  it('bypassSecurityTrustStyle should return provided value', () => {
+    const value = 'color:red';
+    expect(sanitizer.bypassSecurityTrustStyle(value)).toBe(value as any);
+  });
+
+  it('bypassSecurityTrustScript should return provided value', () => {
+    const value = 'alert(1)';
+    expect(sanitizer.bypassSecurityTrustScript(value)).toBe(value as any);
+  });
+
+  it('bypassSecurityTrustUrl should return provided value', () => {
+    const value = 'http://example.com';
+    expect(sanitizer.bypassSecurityTrustUrl(value)).toBe(value as any);
+  });
+});

--- a/src/app/shared/mocks/mocks.spec.ts
+++ b/src/app/shared/mocks/mocks.spec.ts
@@ -1,0 +1,108 @@
+import { mockResponseCliente, mockClienteBody, mockClienteRegisterResponse } from './cliente.mock';
+import { mockDomicilioRespone, mockDomiciliosRespone, mockDomicilioBody } from './domicilio.mock';
+import { mockHttpError500, mockHttpError400 } from './error.mock';
+import { mockLogin, mockLoginResponse } from './login.mock';
+import { mockMetodoPagoRespone, mockMetodosPagoRespone, mockMetodoPagoBody } from './metodo-pago.mock';
+import { mockNominaTrabajadorResponse, mockNominaTrabajadorMes } from './nomina-trabajador.mock';
+import { mockNominaResponse, mockNominaFecha, mockNominaBody, mockNominaPagaResponse } from './nomina.mock';
+import { mockPagosResponse, mockPagoResponse, mockPagoBody } from './pago.mock';
+import { mockPedidoClienteResponse } from './pedido-cliente.mocks';
+import { mockPedidosResponse, mockPedidoBody, mockPedidoDetalle } from './pedido.mock';
+import { mockProductoResponse, mockProductosResponse, mockProductosSinImagenResponse } from './producto.mock';
+import { mockProductoPedidoResponse } from './producto-pedido.mock';
+import { mockReserva, mockReservaResponse, mockReservasDelDiaResponse, mockReservaUpdateResponse, mockReservasUnordered, mockReservaBody } from './reserva.mocks';
+import { mockRestaurantesResponse, mockRestauranteResponse, mockCambioHorarioResponse, mockCambioHorarioAbiertoResponse, mockCambioHorarioBody } from './restaurante.mock';
+import { mockTrabajadorResponse, mockTrabajadorBody, mockTrabajadorRegisterResponse } from './trabajador.mock';
+
+// simple tests to ensure mocks are loaded correctly
+
+describe('shared mocks', () => {
+  it('cliente mocks', () => {
+    expect(mockResponseCliente.data.nombre).toBe('Carlos');
+    expect(mockClienteBody.telefono).toBe('3216549870');
+    expect(mockClienteRegisterResponse.code).toBe(201);
+  });
+
+  it('domicilio mocks', () => {
+    expect(mockDomicilioRespone.data.telefono).toBe('3042449339');
+    expect(mockDomiciliosRespone.data).toHaveLength(2);
+    expect(mockDomicilioBody.entregado).toBe(false);
+  });
+
+  it('error mocks', () => {
+    expect(mockHttpError500.status).toBe(500);
+    expect(mockHttpError400.status).toBe(400);
+  });
+
+  it('login mocks', () => {
+    expect(mockLogin.documento).toBe('12345');
+    expect(mockLoginResponse.data.token).toBe('testToken');
+  });
+
+  it('metodo pago mocks', () => {
+    expect(mockMetodoPagoRespone.data.detalle).toBe('3042449339');
+    expect(mockMetodosPagoRespone.data).toHaveLength(3);
+    expect(mockMetodoPagoBody.tipo).toBe('Nequi');
+  });
+
+  it('nomina trabajador mocks', () => {
+    expect(mockNominaTrabajadorResponse.data).toHaveLength(2);
+    expect(mockNominaTrabajadorMes.data[0].sueldoBase).toBe(2000000);
+  });
+
+  it('nomina mocks', () => {
+    expect(mockNominaResponse.data[0].monto).toBe(5500000);
+    expect(mockNominaFecha.data[0].estadoNomina).toBeDefined();
+    expect(mockNominaBody.estadoNomina).toBeDefined();
+    expect(mockNominaPagaResponse.data.estadoNomina).toBeDefined();
+  });
+
+  it('pago mocks', () => {
+    expect(mockPagosResponse.data).toHaveLength(2);
+    expect(mockPagoResponse.data.monto).toBe(2000);
+    expect(mockPagoBody.estadoPago).toBeDefined();
+  });
+
+  it('pedido cliente mocks', () => {
+    expect(mockPedidoClienteResponse.data).toHaveLength(3);
+  });
+
+  it('pedido mocks', () => {
+    expect(mockPedidosResponse.data).toHaveLength(3);
+    expect(mockPedidoBody.delivery).toBe(true);
+    expect(mockPedidoDetalle.data.METODO_PAGO).toBe('Nequi');
+  });
+
+  it('producto mocks', () => {
+    expect(mockProductoResponse.data.nombre).toBe('Coca Cola Zero 500ml');
+    expect(mockProductosResponse.data[0].nombre).toBe('Pepsi 500ml');
+    expect(mockProductosSinImagenResponse.data).toHaveLength(3);
+  });
+
+  it('producto pedido mocks', () => {
+    expect(mockProductoPedidoResponse.data.detallesProductos[0].nombre).toContain('Coca Cola');
+  });
+
+  it('reserva mocks', () => {
+    expect(mockReserva.reservaId).toBe(1);
+    expect(mockReservaResponse.data).toEqual(mockReserva);
+    expect(mockReservasDelDiaResponse.data).toHaveLength(2);
+    expect(mockReservaUpdateResponse.data).toEqual(mockReserva);
+    expect(mockReservasUnordered).toHaveLength(3);
+    expect(mockReservaBody.documentoCliente).toBe(1015466494);
+  });
+
+  it('restaurante mocks', () => {
+    expect(mockRestaurantesResponse.data[0].nombreRestaurante).toBe('La cocina de María');
+    expect(mockRestauranteResponse.data.restauranteId).toBe(1);
+    expect(mockCambioHorarioResponse.data.cambioHorarioId).toBe(1);
+    expect(mockCambioHorarioAbiertoResponse.data.abierto).toBe(false);
+    expect(mockCambioHorarioBody.abierto).toBe(false);
+  });
+
+  it('trabajador mocks', () => {
+    expect(mockTrabajadorResponse.data.nombre).toBe('Bryan');
+    expect(mockTrabajadorBody.nuevo).toBe(true);
+    expect(mockTrabajadorRegisterResponse.data.apellido).toBe('Luis');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for FakeDomSanitizer
- add unit tests covering all shared mock data

## Testing
- `npm test -- src/app/shared/mocks --collectCoverageFrom=src/app/shared/mocks/**/!(*.spec).ts`


------
https://chatgpt.com/codex/tasks/task_e_689fe22b5dc883258d34ea2d8f5e644b