### PR TITLE
test(client): cobertura completa de PerfilComponent

### DIFF
--- a/src/app/modules/client/perfil/perfil.component.spec.ts
+++ b/src/app/modules/client/perfil/perfil.component.spec.ts
@@ -1,25 +1,18 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { PerfilComponent } from './perfil';
-import { UserService } from '../../../core/services/user.service';
-import { ClienteService } from '../../../core/services/cliente.service';
-import { ToastrService } from 'ngx-toastr';
-import { of } from 'rxjs';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+import { PerfilComponent } from './perfil';
+import { ClienteService } from '../../../core/services/cliente.service';
+import { UserService } from '../../../core/services/user.service';
+import { ToastrService } from 'ngx-toastr';
 
 describe('PerfilComponent', () => {
-  let component: PerfilComponent;
-  let fixture: ComponentFixture<PerfilComponent>;
-
-  beforeEach(async () => {
-    const userServiceMock = {
-      getUserId: jest.fn().mockReturnValue(1),
-      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
-    } as unknown as UserService;
-    const clienteServiceMock = {
-      getClienteId: jest.fn().mockReturnValue(of({ data: {} })),
-    } as unknown as ClienteService;
-    const toastrMock = { error: jest.fn() } as unknown as ToastrService;
-
+  const setup = async (
+    userServiceMock: Partial<UserService>,
+    clienteServiceMock: Partial<ClienteService>,
+    toastrMock: Partial<ToastrService> = { error: jest.fn() }
+  ) => {
     await TestBed.configureTestingModule({
       imports: [PerfilComponent, RouterTestingModule],
       providers: [
@@ -29,12 +22,138 @@ describe('PerfilComponent', () => {
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(PerfilComponent);
-    component = fixture.componentInstance;
+    const fixture = TestBed.createComponent(PerfilComponent);
+    const component = fixture.componentInstance;
+    const router = TestBed.inject(Router);
+    return { fixture, component, router, toastrMock, clienteServiceMock };
+  };
+
+  it('should load client data successfully', async () => {
+    const userServiceMock = {
+      getUserId: jest.fn().mockReturnValue(1),
+      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
+    } as Partial<UserService>;
+    const clienteData = {
+      direccion: 'Calle 1',
+      telefono: '123456',
+      observaciones: 'Cliente frecuente',
+      correo: 'test@example.com',
+    };
+    const clienteServiceMock = {
+      getClienteId: jest.fn().mockReturnValue(of({ data: clienteData })),
+    } as Partial<ClienteService>;
+
+    const { fixture, component, router } = await setup(
+      userServiceMock,
+      clienteServiceMock
+    );
+    const navigateSpy = jest.spyOn(router, 'navigate');
     fixture.detectChanges();
+
+    expect(component.direccion).toBe('Calle 1');
+    expect(component.telefono).toBe('123456');
+    expect(component.observaciones).toBe('Cliente frecuente');
+    expect(component.correo).toBe('test@example.com');
+    expect(component.cargando).toBe(false);
+    expect(component.errorCargando).toBe(false);
+    expect(navigateSpy).not.toHaveBeenCalled();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should navigate to login when user id is missing', async () => {
+    const userServiceMock = {
+      getUserId: jest.fn().mockReturnValue(0),
+      decodeToken: jest.fn(),
+    } as Partial<UserService>;
+    const clienteServiceMock = {
+      getClienteId: jest.fn(),
+    } as Partial<ClienteService>;
+
+    const { fixture, router, clienteServiceMock: clienteMock } = await setup(
+      userServiceMock,
+      clienteServiceMock
+    );
+    const navigateSpy = jest.spyOn(router, 'navigate');
+    fixture.detectChanges();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/login']);
+    expect(clienteMock.getClienteId).not.toHaveBeenCalled();
+  });
+
+  it('should handle error when service fails', async () => {
+    const userServiceMock = {
+      getUserId: jest.fn().mockReturnValue(1),
+      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
+    } as Partial<UserService>;
+    const clienteServiceMock = {
+      getClienteId: jest
+        .fn()
+        .mockReturnValue(throwError(() => new Error('fail'))),
+    } as Partial<ClienteService>;
+    const toastrMock = { error: jest.fn() } as Partial<ToastrService>;
+
+    const { fixture, component } = await setup(
+      userServiceMock,
+      clienteServiceMock,
+      toastrMock
+    );
+    fixture.detectChanges();
+
+    expect(toastrMock.error).toHaveBeenCalledWith(
+      'Error al cargar los datos del cliente',
+      'Error'
+    );
+    expect(component.direccion).toBe('No registrada');
+    expect(component.telefono).toBe('No registrado');
+    expect(component.observaciones).toBe('');
+    expect(component.cargando).toBe(false);
+    expect(component.errorCargando).toBe(true);
+  });
+
+  it('should leave observaciones empty when not frequent client', async () => {
+    const userServiceMock = {
+      getUserId: jest.fn().mockReturnValue(1),
+      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
+    } as Partial<UserService>;
+    const clienteData = {
+      direccion: 'Calle 2',
+      telefono: '654321',
+      observaciones: 'Ocasional',
+      correo: 'mail@test.com',
+    };
+    const clienteServiceMock = {
+      getClienteId: jest.fn().mockReturnValue(of({ data: clienteData })),
+    } as Partial<ClienteService>;
+
+    const { fixture, component } = await setup(
+      userServiceMock,
+      clienteServiceMock
+    );
+    fixture.detectChanges();
+
+    expect(component.observaciones).toBe('');
+    expect(component.direccion).toBe('Calle 2');
+    expect(component.telefono).toBe('654321');
+  });
+
+  it('should use default values when response has no data and token lacks name', async () => {
+    const userServiceMock = {
+      getUserId: jest.fn().mockReturnValue(1),
+      decodeToken: jest.fn().mockReturnValue(undefined),
+    } as Partial<UserService>;
+    const clienteServiceMock = {
+      getClienteId: jest.fn().mockReturnValue(of({})),
+    } as Partial<ClienteService>;
+
+    const { fixture, component } = await setup(
+      userServiceMock,
+      clienteServiceMock
+    );
+    fixture.detectChanges();
+
+    expect(component.nombre).toBe('Cliente');
+    expect(component.direccion).toBe('No registrada');
+    expect(component.telefono).toBe('No registrado');
+    expect(component.correo).toBe('No registrado');
   });
 });
+

--- a/src/app/modules/client/perfil/perfil.ts
+++ b/src/app/modules/client/perfil/perfil.ts
@@ -36,7 +36,7 @@ export class PerfilComponent implements OnInit {
     this.documento = this.userService.getUserId();
 
     // Si no hay documento en el token → sesión inválida
-    if (!this.documento || this.documento === 0) {
+      if (!this.documento) {
       this.router.navigate(['/login']);
       return;
     }
@@ -51,7 +51,8 @@ export class PerfilComponent implements OnInit {
         const data = response?.data ?? null;
         this.direccion = data?.direccion ?? 'No registrada';
         this.telefono = data?.telefono ?? 'No registrado';
-        this.observaciones = data?.observaciones === 'Cliente frecuente' ? data?.observaciones ?? '' : '';
+        this.observaciones =
+          data?.observaciones === 'Cliente frecuente' ? 'Cliente frecuente' : '';
         this.correo = data?.correo ?? 'No registrado';
         this.cargando = false;
         this.errorCargando = false;


### PR DESCRIPTION
## Summary
- simplifica validación de documento en PerfilComponent
- agrega pruebas para todos los escenarios del PerfilComponent

## Testing
- `npm test -- src/app/modules/client/perfil/perfil.component.spec.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe4ded27483258cb764d372a8232f