### PR TITLE
test: add full coverage tests for consultar reserva component

### DIFF
--- a/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts
+++ b/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts
@@ -16,6 +16,7 @@ import {
   mockReservasUnordered,
 } from '../../../../shared/mocks/reserva.mocks';
 import { UserService } from '../../../../core/services/user.service';
+
 describe('ConsultarReservaComponent', () => {
   let component: ConsultarReservaComponent;
   let fixture: ComponentFixture<ConsultarReservaComponent>;
@@ -139,7 +140,6 @@ describe('ConsultarReservaComponent', () => {
 
     reservaService.actualizarReserva.mockReturnValue(of(mockUpdateResponse));
 
-
     component.cancelarReserva(mockReserva);
 
     expect(reservaService.actualizarReserva).toHaveBeenCalledWith(1, expect.objectContaining({ estadoReserva: 'CANCELADA' }));
@@ -154,7 +154,6 @@ describe('ConsultarReservaComponent', () => {
     };
 
     reservaService.actualizarReserva.mockReturnValue(of(mockUpdateResponse));
-
 
     component.cumplirReserva(mockReserva);
 
@@ -175,6 +174,7 @@ describe('ConsultarReservaComponent', () => {
     component.confirmarReserva(invalidReserva);
     expect(toastr.error).toHaveBeenCalledWith('Error: ID de reserva no válido', 'Error');
   });
+
   it('should sort reservations by date (desc) and time (desc)', () => {
     reservaService.getReservaByParameter.mockReturnValue(of({ code: 200, message: 'Reservas obtenidas', data: mockReservasUnordered }));
 
@@ -191,6 +191,76 @@ describe('ConsultarReservaComponent', () => {
         { fecha: '01-01-2025', hora: '14:00' }
       ]);
   });
+
+  it('should initialize as non-admin and load reservations', () => {
+    userService.getUserRole.mockReturnValue('Cliente');
+    userService.getUserId.mockReturnValue(123456);
+    reservaService.getReservaByParameter.mockReturnValue(
+      of({ code: 200, message: 'Reservas obtenidas', data: [mockReserva] })
+    );
+
+    component.ngOnInit();
+
+    expect(component.esAdmin).toBe(false);
+    expect(component.mostrarFiltros).toBe(false);
+    expect(component.documentoCliente).toBe('123456');
+    expect(component.buscarPorDocumento).toBe(true);
+    expect(component.buscarPorFecha).toBe(false);
+    expect(reservaService.getReservaByParameter).toHaveBeenCalledWith(123456, undefined);
+    expect(component.reservas).toEqual([mockReserva]);
+    expect(component.mostrarMensaje).toBe(true);
+  });
+
+  it('should warn on init when non-admin has no document', () => {
+    userService.getUserRole.mockReturnValue('Cliente');
+    userService.getUserId.mockReturnValue(undefined as unknown as number);
+
+    component.ngOnInit();
+
+    expect(component.documentoCliente).toBe('');
+    expect(toastr.warning).toHaveBeenCalledWith('Por favor ingresa un documento', 'Atención');
+  });
+
+  it('should use user id when no criteria provided for non-admin', () => {
+    userService.getUserId.mockReturnValue(123456);
+    component.esAdmin = false;
+    component.mostrarFiltros = false;
+    component.buscarPorDocumento = false;
+    component.buscarPorFecha = false;
+    component.documentoCliente = '';
+    reservaService.getReservaByParameter.mockReturnValue(
+      of({ code: 200, message: 'Reservas obtenidas', data: [mockReserva] })
+    );
+
+    component.buscarReserva();
+
+    expect(reservaService.getReservaByParameter).toHaveBeenCalledWith(123456, undefined);
+  });
+
+  it('should call service with undefined when user id is missing for non-admin', () => {
+    userService.getUserId.mockReturnValue(undefined as unknown as number);
+    component.esAdmin = false;
+    component.mostrarFiltros = false;
+    component.buscarPorDocumento = false;
+    component.buscarPorFecha = false;
+    component.documentoCliente = '';
+    reservaService.getReservaByParameter.mockReturnValue(
+      of({ code: 200, message: 'Reservas obtenidas', data: [mockReserva] })
+    );
+
+    component.buscarReserva();
+
+    expect(reservaService.getReservaByParameter).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it('should not update reservation when user is not admin', () => {
+    component.esAdmin = false;
+
+    component.confirmarReserva(mockReserva);
+
+    expect(reservaService.actualizarReserva).not.toHaveBeenCalled();
+  });
+
   it('should return the same date if it has three parts', () => {
     const result = component['convertirFechaISO']('2025-01-15');
     expect(result).toBe('2025-01-15');
@@ -200,14 +270,4 @@ describe('ConsultarReservaComponent', () => {
     const result = component['convertirFechaISO']('invalid-date');
     expect(result).toBe('invalid-date');
   });
-  it('should return the same date if it has three parts', () => {
-    const result = component['convertirFechaISO']('2025-01-15');
-    expect(result).toBe('2025-01-15');
-  });
-
-  it('should return the original string if it does not have three parts', () => {
-    const result = component['convertirFechaISO']('invalid-date');
-    expect(result).toBe('invalid-date');
-  });
-
 });


### PR DESCRIPTION
## Summary
- add comprehensive tests for ConsultarReservaComponent including non-admin flows
- ensure reservations search and update paths are fully covered

## Testing
- `npx jest src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts --coverage --collectCoverageFrom=src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.ts --silent`

------
https://chatgpt.com/codex/tasks/task_e_689fe4a8c53483259a7d98be58ac0362