### PR TITLE
test: increase producto filtro coverage

### DIFF
--- a/src/app/shared/pipes/producto-filtro.pipe.spec.ts
+++ b/src/app/shared/pipes/producto-filtro.pipe.spec.ts
@@ -1,8 +1,103 @@
 import { ProductoFiltroPipe } from './producto-filtro.pipe';
+import { Producto } from '../models/producto.model';
 
 describe('ProductoFiltroPipe', () => {
+  let pipe: ProductoFiltroPipe;
+  let productos: Producto[];
+
+  beforeEach(() => {
+    pipe = new ProductoFiltroPipe();
+    productos = [
+      {
+        nombre: 'Hamburguesa',
+        precio: 10,
+        cantidad: 1,
+        categoria: 'Comida',
+        subcategoria: 'Rapida',
+        calorias: 500,
+      },
+      {
+        nombre: 'Ensalada',
+        precio: 8,
+        cantidad: 1,
+        categoria: 'Comida',
+        subcategoria: 'Saludable',
+        calorias: 200,
+      },
+      {
+        nombre: 'Jugo',
+        precio: 5,
+        cantidad: 1,
+        categoria: 'Bebida',
+        subcategoria: 'Natural',
+        calorias: 150,
+      },
+      {
+        nombre: 'Agua',
+        precio: 1,
+        cantidad: 1,
+        categoria: 'Bebida',
+        subcategoria: 'Natural',
+      },
+      {
+        nombre: 'Mystery',
+        precio: 2,
+        cantidad: 1,
+        calorias: 50,
+      },
+    ];
+  });
+
   it('create an instance', () => {
-    const pipe = new ProductoFiltroPipe();
     expect(pipe).toBeTruthy();
   });
+
+  it('should return empty array when productos is null', () => {
+    expect(pipe.transform(null as unknown as Producto[])).toEqual([]);
+  });
+
+  it('should return all products with calorias when no filters are applied', () => {
+    expect(pipe.transform(productos)).toEqual([
+      productos[0],
+      productos[1],
+      productos[2],
+      productos[4],
+    ]);
+  });
+
+  it('should filter by nombre', () => {
+    expect(pipe.transform(productos, 'ensalada')).toEqual([productos[1]]);
+  });
+
+  it('should filter by categoria', () => {
+    expect(pipe.transform(productos, '', 'bebida')).toEqual([productos[2]]);
+  });
+
+  it('should filter by subcategoria', () => {
+    expect(pipe.transform(productos, '', '', 'natural')).toEqual([productos[2]]);
+  });
+
+  it('should filter by minCalorias', () => {
+    expect(pipe.transform(productos, '', '', '', 100)).toEqual([
+      productos[0],
+      productos[1],
+      productos[2],
+    ]);
+  });
+
+  it('should filter by maxCalorias', () => {
+    expect(pipe.transform(productos, '', '', '', undefined, 200)).toEqual([
+      productos[1],
+      productos[2],
+      productos[4],
+    ]);
+  });
+
+  it('should filter by calorias range', () => {
+    expect(pipe.transform(productos, '', '', '', 100, 300)).toEqual([
+      productos[1],
+      productos[2],
+    ]);
+  });
 });
+


### PR DESCRIPTION
## Summary
- add exhaustive tests for `ProductoFiltroPipe`
- ensure filtering by name, category, subcategory, and calorie ranges

## Testing
- `npm test`
- `npx jest src/app/shared/pipes --coverage --collectCoverageFrom='src/app/shared/pipes/*.ts' --coverageReporters='text-summary'`


------
https://chatgpt.com/codex/tasks/task_e_689fe8063c1883258638c333f8dbc469