### PR TITLE
test: ensure full coverage for reservas components

### DIFF
--- a/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.spec.ts
+++ b/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.spec.ts
@@ -309,7 +309,7 @@ describe('CrearReservaComponent', () => {
   });
   it('should set userId to 0 when getUserId returns null', () => {
     component.rol = 'Otro';
-    userService.getUserId.mockReturnValue(0);
+    userService.getUserId.mockReturnValue(null);
     component.fechaReserva = "2025-02-06";
     component.horaReserva = "10:00";
     component.personas = "3";

--- a/src/app/modules/public/reservas/menu-reservas/menu-reservas.component.spec.ts
+++ b/src/app/modules/public/reservas/menu-reservas/menu-reservas.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MenuReservasComponent } from './menu-reservas.component';
-import { Router, NavigationEnd, RouterOutlet } from '@angular/router';
+import { Router, NavigationEnd } from '@angular/router';
 import { UserService } from '../../../../core/services/user.service';
 import { Subject } from 'rxjs';
 import { CommonModule } from '@angular/common';
@@ -14,6 +14,7 @@ describe('MenuReservasComponent', () => {
 
   beforeEach(async () => {
     eventsSubject = new Subject<any>();
+
     const routerMock = {
       navigate: jest.fn(),
       events: eventsSubject.asObservable(),
@@ -21,52 +22,71 @@ describe('MenuReservasComponent', () => {
     } as unknown as jest.Mocked<Router>;
 
     const userServiceMock = {
-      getUserRole: jest.fn()
+      getUserRole: jest.fn(),
     } as unknown as jest.Mocked<UserService>;
 
     await TestBed.configureTestingModule({
       imports: [MenuReservasComponent, CommonModule],
       providers: [
         { provide: Router, useValue: routerMock },
-        { provide: UserService, useValue: userServiceMock }
-      ]
+        { provide: UserService, useValue: userServiceMock },
+      ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(MenuReservasComponent);
-    component = fixture.componentInstance;
     router = TestBed.inject(Router) as jest.Mocked<Router>;
     userService = TestBed.inject(UserService) as jest.Mocked<UserService>;
-    fixture.detectChanges();
   });
 
+  const createComponent = () => {
+    fixture = TestBed.createComponent(MenuReservasComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
   it('should create', () => {
+    createComponent();
     expect(component).toBeTruthy();
   });
 
   describe('ngOnInit', () => {
-    it('should set role and esAdmin to true for Administrador and navigate to "crear"', () => {
+    it('should set role and esAdmin to true for Administrador and not navigate', () => {
       userService.getUserRole.mockReturnValue('Administrador');
-      fixture = TestBed.createComponent(MenuReservasComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
+      router.url = '/reservas';
+      createComponent();
 
       expect(component.rol).toBe('Administrador');
       expect(component.esAdmin).toBe(true);
-      expect(router.navigate).toHaveBeenCalled();
+      expect(router.navigate).not.toHaveBeenCalled();
     });
 
     it('should set role and esAdmin to false for non-admin and navigate to "crear"', () => {
       userService.getUserRole.mockReturnValue('Cliente');
-
-      component.ngOnInit();
+      router.url = '/reservas';
+      createComponent();
 
       expect(component.rol).toBe('Cliente');
       expect(component.esAdmin).toBe(false);
       expect(router.navigate).toHaveBeenCalledWith(['/reservas/crear']);
     });
+
+    it('should set mostrarMenu to true when currentUrl is "/reservas/"', () => {
+      userService.getUserRole.mockReturnValue('Administrador');
+      router.url = '/reservas/';
+      createComponent();
+
+      expect(component.mostrarMenu).toBe(true);
+      expect(router.navigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('router events subscription', () => {
+    beforeEach(() => {
+      userService.getUserRole.mockReturnValue('Administrador');
+      router.url = '/reservas';
+      createComponent();
+      router.navigate.mockClear();
+    });
+
     it('should set mostrarMenu to true when NavigationEnd event urlAfterRedirects is "/reservas"', () => {
       eventsSubject.next(new NavigationEnd(1, '/reservas', '/reservas'));
       expect(component.mostrarMenu).toBe(true);
@@ -79,6 +99,13 @@ describe('MenuReservasComponent', () => {
   });
 
   describe('irA and volver methods', () => {
+    beforeEach(() => {
+      userService.getUserRole.mockReturnValue('Administrador');
+      router.url = '/reservas';
+      createComponent();
+      router.navigate.mockClear();
+    });
+
     it('irA should navigate to the given route under /reservas', () => {
       component.irA('detalle');
       expect(router.navigate).toHaveBeenCalledWith(['/reservas/detalle']);
@@ -90,3 +117,4 @@ describe('MenuReservasComponent', () => {
     });
   });
 });
+


### PR DESCRIPTION
## Summary
- add comprehensive MenuReservasComponent tests including trailing slash handling
- cover null userId path in CrearReservaComponent tests
- achieve 100% Jest coverage across statements, branches, functions and lines

## Testing
- `npm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_689feb7deb5c8325892936f289a39024