### PR TITLE
fix: prepend bearer token

### DIFF
--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -34,7 +34,7 @@ describe('authInterceptor', () => {
     interceptor(request, next);
 
     const modifiedRequest = next.mock.calls[0][0];
-    expect(modifiedRequest.headers.get('Authorization')).toBe(token);
+    expect(modifiedRequest.headers.get('Authorization')).toBe(`Bearer ${token}`);
   });
 
   it('should not modify request if validToken is not present', () => {

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -9,7 +9,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
   if (validToken) {
     const authReq = req.clone({
       setHeaders: {
-        Authorization: validToken,
+        Authorization: `Bearer ${validToken}`,
       },
     });
     return next(authReq);


### PR DESCRIPTION
## Summary
- prefix `Authorization` header with `Bearer`
- update interceptor tests to match bearer token

## Testing
- `CI=true npm test`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c630d7f08325acb9e1fd879c6678