### PR TITLE
feat(core): add configurable fallback route for role guard

### DIFF
--- a/src/app/core/guards/role.guard.spec.ts
+++ b/src/app/core/guards/role.guard.spec.ts
@@ -59,7 +59,7 @@ describe('RoleGuard', () => {
 
     expect(result).toBe(false);
     expect(toastr.error).toHaveBeenCalledWith('No tienes permisos para acceder a esta página', 'Acceso denegado');
-    expect(router.navigate).toHaveBeenCalledWith(['/reservas/crear']);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
   });
 
   it('should deny access and redirect if user has no role', () => {
@@ -69,6 +69,19 @@ describe('RoleGuard', () => {
 
     expect(result).toBe(false);
     expect(toastr.error).toHaveBeenCalledWith('No tienes permisos para acceder a esta página', 'Acceso denegado');
-    expect(router.navigate).toHaveBeenCalledWith(['/reservas/crear']);
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  it('should use custom fallback route when provided', () => {
+    const customRoute = {
+      data: { roles: ['Administrador'], fallbackRoute: '/not-found' }
+    } as unknown as ActivatedRouteSnapshot;
+
+    userService.getUserRole.mockReturnValue('cliente');
+
+    const result = roleGuard.canActivate(customRoute);
+
+    expect(result).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/not-found']);
   });
 });

--- a/src/app/core/guards/role.guard.ts
+++ b/src/app/core/guards/role.guard.ts
@@ -15,7 +15,8 @@ export class RoleGuard implements CanActivate {
 
     if (!userRole || !expectedRoles.includes(userRole)) {
       this.toastr.error('No tienes permisos para acceder a esta página', 'Acceso denegado');
-      this.router.navigate(['/reservas/crear']);
+      const fallbackRoute = route.data['fallbackRoute'] || '/login';
+      this.router.navigate([fallbackRoute]);
       return false;
     }
 


### PR DESCRIPTION
## Summary
- redirect unauthorized roles to `/login` by default
- support custom fallback via `route.data.fallbackRoute`
- test role guard redirection and custom fallback path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c72b098c8325ade8f7248d4f47f2