### PR TITLE
feat: make safe pipe standalone

### DIFF
--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -14,7 +14,7 @@ import { SafePipe } from "../../../../shared/pipes/safe.pipe";
   standalone: true,
   templateUrl: './ruta-domicilio.component.html',
   styleUrls: ['./ruta-domicilio.component.scss'],
-  imports: [CommonModule]
+  imports: [CommonModule, SafePipe]
 })
 export class RutaDomicilioComponent implements OnInit {
   ubicacionUrl: SafeResourceUrl | undefined;

--- a/src/app/shared/pipes/safe.pipe.ts
+++ b/src/app/shared/pipes/safe.pipe.ts
@@ -9,7 +9,8 @@ import {
 } from '@angular/platform-browser';
 
 @Pipe({
-  name: 'safe'
+  name: 'safe',
+  standalone: true
 })
 export class SafePipe implements PipeTransform {
   constructor(protected sanitizer: DomSanitizer) { }


### PR DESCRIPTION
## Summary
- make SafePipe standalone so it can be imported directly
- import SafePipe into RutaDomicilioComponent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c65499188325be0f82c945a6a30e