### PR TITLE
refactor: use absolute navigation paths

### DIFF
--- a/src/app/modules/admin/productos/menu-productos/productos.component.spec.ts
+++ b/src/app/modules/admin/productos/menu-productos/productos.component.spec.ts
@@ -62,7 +62,7 @@ describe('ProductosComponent', () => {
   it('irA crear should navigate to admin/productos/crear', () => {
     const navigateSpy = jest.spyOn(router, 'navigate');
     component.irA('crear');
-    expect(navigateSpy).toHaveBeenCalledWith(['admin/productos/crear']);
+    expect(navigateSpy).toHaveBeenCalledWith(['/admin', 'productos', 'crear']);
   });
 
   it('volver should navigate to /admin/productos', () => {

--- a/src/app/modules/admin/productos/menu-productos/productos.component.ts
+++ b/src/app/modules/admin/productos/menu-productos/productos.component.ts
@@ -35,7 +35,7 @@ export class ProductosComponent implements OnInit {
       this.router.navigate(['/menu']);
     } else {
       // Carga dentro del router-outlet hijo
-      this.router.navigate(['admin/productos/crear']);
+      this.router.navigate(['/admin', 'productos', 'crear']);
     }
   }
 

--- a/src/app/modules/trabajadores/domicilios/tomar-domicilio/tomar-domicilio.component.spec.ts
+++ b/src/app/modules/trabajadores/domicilios/tomar-domicilio/tomar-domicilio.component.spec.ts
@@ -182,7 +182,7 @@ describe('TomarDomicilioComponent', () => {
 
     component.irARuta(domicilio);
     expect(navigateSpy).toHaveBeenCalledWith(
-      ['trabajador/domicilios/ruta-domicilio'],
+      ['/trabajador', 'domicilios', 'ruta-domicilio'],
       {
         queryParams: {
           direccion: 'Street',
@@ -208,7 +208,7 @@ describe('TomarDomicilioComponent', () => {
 
     component.irARuta(sinObs);
     expect(navigateSpy).toHaveBeenCalledWith(
-      ['trabajador/domicilios/ruta-domicilio'],
+      ['/trabajador', 'domicilios', 'ruta-domicilio'],
       {
         queryParams: {
           direccion: 'A',

--- a/src/app/modules/trabajadores/domicilios/tomar-domicilio/tomar-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/tomar-domicilio/tomar-domicilio.component.ts
@@ -61,7 +61,7 @@ export class TomarDomicilioComponent implements OnInit {
   }
 
   irARuta(domicilio: Domicilio): void {
-    this.router.navigate(['trabajador/domicilios/ruta-domicilio'], {
+    this.router.navigate(['/trabajador', 'domicilios', 'ruta-domicilio'], {
       queryParams: {
         direccion: domicilio.direccion,
         telefono: domicilio.telefono,


### PR DESCRIPTION
## Summary
- use absolute admin product creation route in navigation
- adjust domicilio route navigation to absolute path
- update tests for new navigation paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c678db208325aaca87a440d4f859