### PR TITLE
refactor: make components standalone

### DIFF
--- a/src/app/modules/admin/admin.module.ts
+++ b/src/app/modules/admin/admin.module.ts
@@ -2,14 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { adminRoutes } from './admin.routes';
-import { CrearProductoComponent } from './productos/crear-producto/crear-producto.component';
 
 @NgModule({
   declarations: [],
   imports: [
     CommonModule,
     RouterModule.forChild(adminRoutes),
-    CrearProductoComponent
   ],
   exports: [RouterModule]
 })

--- a/src/app/modules/admin/productos/crear-producto/crear-producto.component.ts
+++ b/src/app/modules/admin/productos/crear-producto/crear-producto.component.ts
@@ -9,6 +9,7 @@ import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-crear-producto',
+  standalone: true,
   templateUrl: './crear-producto.component.html',
   styleUrls: ['./crear-producto.component.scss'],
   imports: [CommonModule, FormsModule]

--- a/src/app/modules/admin/productos/menu-productos/productos.component.ts
+++ b/src/app/modules/admin/productos/menu-productos/productos.component.ts
@@ -5,6 +5,7 @@ import { UserService } from '../../../../core/services/user.service';
 
 @Component({
   selector: 'app-productos',
+  standalone: true,
   imports: [CommonModule, RouterModule],
   templateUrl: './productos.component.html',
   styleUrl: './productos.component.scss'

--- a/src/app/modules/public/page-not-found/page-not-found.component.ts
+++ b/src/app/modules/public/page-not-found/page-not-found.component.ts
@@ -3,6 +3,7 @@ import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-page-not-found',
+  standalone: true,
   imports: [RouterModule],
   templateUrl: './page-not-found.component.html',
   styleUrl: './page-not-found.component.scss'

--- a/src/app/modules/trabajadores/domicilios/tomar-domicilio/tomar-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/tomar-domicilio/tomar-domicilio.component.ts
@@ -8,6 +8,7 @@ import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-tomar-domicilio',
+  standalone: true,
   templateUrl: './tomar-domicilio.component.html',
   styleUrls: ['./tomar-domicilio.component.scss'],
   imports: [CommonModule, FormsModule]


### PR DESCRIPTION
## Summary
- mark page-not-found component as standalone
- mark admin product management components as standalone
- mark domicilio taking component as standalone
- drop CrearProductoComponent from AdminModule imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0c60268408325954c2966b8fd86f0