### PR TITLE
refactor: inject FormatDatePipe

### DIFF
--- a/src/app/modules/auth/register/register.component.ts
+++ b/src/app/modules/auth/register/register.component.ts
@@ -13,7 +13,8 @@ import { TrabajadorService } from '../../../core/services/trabajador.service';
 
 @Component({
   selector: 'app-register',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, FormatDatePipe],
+  providers: [FormatDatePipe],
   standalone: true,
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss'],
@@ -45,7 +46,8 @@ export class RegisterComponent implements OnInit {
     private trabajadorService: TrabajadorService,
     private clienteService: ClienteService,
     private toastr: ToastrService,
-    private router: Router
+    private router: Router,
+    private formatDatePipe: FormatDatePipe
   ) {
   }
 
@@ -66,8 +68,8 @@ export class RegisterComponent implements OnInit {
 
 
   onSubmit(): void {
-    const formattedFechaNacimiento = new FormatDatePipe().transform(this.fechaNacimiento);
-    const formattedFechaIngreso = new FormatDatePipe().transform(new Date())
+    const formattedFechaNacimiento = this.formatDatePipe.transform(this.fechaNacimiento);
+    const formattedFechaIngreso = this.formatDatePipe.transform(new Date());
     if (this.esTrabajador) {
       const trabajador: Trabajador = {
         documentoTrabajador: this.documento,


### PR DESCRIPTION
## Summary
- inject `FormatDatePipe` into RegisterComponent
- use injected `formatDatePipe` instead of creating new instances

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c65d402c832582bee9e6bca7738b