### PR TITLE
refactor: replace console logs with logging service

### DIFF
--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoggingService {
+  log(message: any, ...optionalParams: any[]): void {
+    console.info(message, ...optionalParams);
+  }
+
+  error(message: any, ...optionalParams: any[]): void {
+    console.error(message, ...optionalParams);
+  }
+
+  warn(message: any, ...optionalParams: any[]): void {
+    console.warn(message, ...optionalParams);
+  }
+}
+

--- a/src/app/core/services/modal.service.spec.ts
+++ b/src/app/core/services/modal.service.spec.ts
@@ -1,11 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 import { ModalService } from './modal.service';
+import { LoggingService } from './logging.service';
 
 describe('ModalService', () => {
   let service: ModalService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [LoggingService]
+    });
     service = TestBed.inject(ModalService);
   });
 

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { LoggingService } from './logging.service';
 
 @Injectable({
   providedIn: 'root',
@@ -10,8 +11,10 @@ export class ModalService {
   private isOpen = new BehaviorSubject<boolean>(false);
   isOpen$ = this.isOpen.asObservable();
 
+  constructor(private logger: LoggingService) {}
+
   openModal(data: any) {
-    console.log('Entra');
+    this.logger.log('Entra');
     this.modalData.next(data);
     this.isOpen.next(true);
   }
@@ -19,9 +22,9 @@ export class ModalService {
   closeModal() {
     this.isOpen.next(false);
   }
+
   getModalData(): any {
-    console.log('getModalData')
+    this.logger.log('getModalData');
     return this.modalData.value;
   }
-  
 }

--- a/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts
+++ b/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts
@@ -16,6 +16,7 @@ import {
   mockReservasUnordered,
 } from '../../../../shared/mocks/reserva.mocks';
 import { UserService } from '../../../../core/services/user.service';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 describe('ConsultarReservaComponent', () => {
   let component: ConsultarReservaComponent;
@@ -23,6 +24,7 @@ describe('ConsultarReservaComponent', () => {
   let reservaService: jest.Mocked<ReservaService>;
   let toastr: jest.Mocked<ToastrService>;
   let userService: jest.Mocked<UserService>;
+  let loggingService: jest.Mocked<LoggingService>;
 
   beforeEach(async () => {
     const reservaServiceMock = {
@@ -41,12 +43,18 @@ describe('ConsultarReservaComponent', () => {
       getUserId: jest.fn().mockReturnValue(123456),
     } as unknown as jest.Mocked<UserService>;
 
+    const loggingServiceMock = {
+      log: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<LoggingService>;
+
     await TestBed.configureTestingModule({
       imports: [ConsultarReservaComponent, FormsModule, CommonModule],
       providers: [
         { provide: ReservaService, useValue: reservaServiceMock },
         { provide: ToastrService, useValue: toastrMock },
         { provide: UserService, useValue: userServiceMock },
+        { provide: LoggingService, useValue: loggingServiceMock },
       ],
     }).compileComponents();
 
@@ -55,6 +63,7 @@ describe('ConsultarReservaComponent', () => {
     reservaService = TestBed.inject(ReservaService) as jest.Mocked<ReservaService>;
     toastr = TestBed.inject(ToastrService) as jest.Mocked<ToastrService>;
     userService = TestBed.inject(UserService) as jest.Mocked<UserService>;
+    loggingService = TestBed.inject(LoggingService) as jest.Mocked<LoggingService>;
 
     fixture.detectChanges();
   });

--- a/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.ts
+++ b/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 import { ReservaService } from '../../../../core/services/reserva.service';
 import { UserService } from '../../../../core/services/user.service';
@@ -29,7 +30,8 @@ export class ConsultarReservaComponent implements OnInit {
   constructor(
     private reservaService: ReservaService,
     private toastr: ToastrService,
-    private userService: UserService
+    private userService: UserService,
+    private logger: LoggingService
   ) {}
 
   ngOnInit(): void {
@@ -149,7 +151,7 @@ export class ConsultarReservaComponent implements OnInit {
         this.toastr.success(`Reserva marcada como ${nuevoEstado}`, 'Actualización Exitosa');
       },
       error: (error) => {
-        console.log('Error:', error);
+        this.logger.error('Error:', error);
         this.toastr.error('Ocurrió un error al actualizar la reserva', 'Error');
       }
     });

--- a/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.spec.ts
+++ b/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.spec.ts
@@ -16,6 +16,7 @@ import { Trabajador } from '../../../../shared/models/trabajador.model';
 import { mockTrabajadorResponse } from '../../../../shared/mocks/trabajador.mock';
 import { mockResponseCliente } from '../../../../shared/mocks/cliente.mock';
 import { ClienteService } from '../../../../core/services/cliente.service';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 describe('CrearReservaComponent', () => {
   let component: CrearReservaComponent;
@@ -26,6 +27,7 @@ describe('CrearReservaComponent', () => {
   let clienteService: jest.Mocked<ClienteService>;
   let toastr: jest.Mocked<ToastrService>;
   let router: jest.Mocked<Router>;
+  let loggingService: jest.Mocked<LoggingService>;
 
   beforeEach(async () => {
     const reservaServiceMock = {
@@ -58,6 +60,11 @@ describe('CrearReservaComponent', () => {
       navigate: jest.fn()
     } as unknown as jest.Mocked<Router>;
 
+    const loggingServiceMock = {
+      log: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<LoggingService>;
+
     await TestBed.configureTestingModule({
       imports: [CrearReservaComponent, FormsModule, CommonModule],
       providers: [
@@ -66,7 +73,8 @@ describe('CrearReservaComponent', () => {
         { provide: TrabajadorService, useValue: trabajadorServiceMock },
         { provide: ClienteService, useValue: clienteServiceMock },
         { provide: ToastrService, useValue: toastrMock },
-        { provide: Router, useValue: routerMock }
+        { provide: Router, useValue: routerMock },
+        { provide: LoggingService, useValue: loggingServiceMock }
       ]
     }).compileComponents();
 
@@ -78,6 +86,7 @@ describe('CrearReservaComponent', () => {
     clienteService = TestBed.inject(ClienteService) as jest.Mocked<ClienteService>;
     toastr = TestBed.inject(ToastrService) as jest.Mocked<ToastrService>;
     router = TestBed.inject(Router) as jest.Mocked<Router>;
+    loggingService = TestBed.inject(LoggingService) as jest.Mocked<LoggingService>;
 
     fixture.detectChanges();
   });
@@ -275,16 +284,12 @@ describe('CrearReservaComponent', () => {
     const errorResponse = new Error("Error creando reserva");
     reservaService.crearReserva.mockReturnValue(throwError(() => errorResponse));
 
-    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => { });
-
     component.onSubmit();
 
     expect(trabajadorService.getTrabajadorId).toHaveBeenCalledWith(1);
-    expect(consoleSpy).toHaveBeenCalledWith('Error al crear la reserva', errorResponse);
+    expect(loggingService.error).toHaveBeenCalledWith('Error al crear la reserva', errorResponse);
     expect(toastr.error).toHaveBeenCalledWith("Error creando reserva", 'Error');
     expect(router.navigate).not.toHaveBeenCalled();
-
-    consoleSpy.mockRestore();
   });
   it('should create reservation with "Anónimo" when no user role is provided', () => {
     component.rol = null;

--- a/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.ts
+++ b/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.ts
@@ -9,6 +9,7 @@ import { UserService } from '../../../../core/services/user.service';
 import { estadoReserva } from '../../../../shared/constants';
 import { Reserva } from '../../../../shared/models/reserva.model';
 import { TrabajadorService } from '../../../../core/services/trabajador.service';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 @Component({
   selector: 'app-reserva',
@@ -41,7 +42,8 @@ export class CrearReservaComponent implements OnInit {
     private trabajadorService: TrabajadorService,
     private clienteService: ClienteService,
     private toastr: ToastrService,
-    private router: Router
+    private router: Router,
+    private logger: LoggingService
   ) { }
 
   ngOnInit(): void {
@@ -134,7 +136,7 @@ export class CrearReservaComponent implements OnInit {
         this.router.navigate(['/reservas']);
       },
       error: (error) => {
-        console.log('Error al crear la reserva', error);
+        this.logger.error('Error al crear la reserva', error);
         this.toastr.error(error.message, 'Error');
       }
     });

--- a/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.spec.ts
+++ b/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.spec.ts
@@ -6,12 +6,14 @@ import { CommonModule } from '@angular/common';
 import { of, throwError } from 'rxjs';
 import { Reserva } from '../../../../shared/models/reserva.model';
 import { mockReservaResponse, mockReservasDelDiaResponse } from '../../../../shared/mocks/reserva.mocks';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 describe('ReservasDelDiaComponent', () => {
   let component: ReservasDelDiaComponent;
   let fixture: ComponentFixture<ReservasDelDiaComponent>;
   let reservaService: jest.Mocked<ReservaService>;
   let toastr: jest.Mocked<ToastrService>;
+  let loggingService: jest.Mocked<LoggingService>;
 
   beforeEach(async () => {
     const reservaServiceMock = {
@@ -24,11 +26,17 @@ describe('ReservasDelDiaComponent', () => {
       error: jest.fn()
     } as unknown as jest.Mocked<ToastrService>;
 
+    const loggingServiceMock = {
+      log: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<LoggingService>;
+
     await TestBed.configureTestingModule({
       imports: [ReservasDelDiaComponent, CommonModule],
       providers: [
         { provide: ReservaService, useValue: reservaServiceMock },
-        { provide: ToastrService, useValue: toastrMock }
+        { provide: ToastrService, useValue: toastrMock },
+        { provide: LoggingService, useValue: loggingServiceMock }
       ]
     }).compileComponents();
 
@@ -36,6 +44,7 @@ describe('ReservasDelDiaComponent', () => {
     component = fixture.componentInstance;
     reservaService = TestBed.inject(ReservaService) as jest.Mocked<ReservaService>;
     toastr = TestBed.inject(ToastrService) as jest.Mocked<ToastrService>;
+    loggingService = TestBed.inject(LoggingService) as jest.Mocked<LoggingService>;
   });
 
   it('should create', () => {
@@ -119,14 +128,10 @@ describe('ReservasDelDiaComponent', () => {
     it('should show error when actualizarReserva fails', () => {
       const errorResponse = new Error('Update failed');
       reservaService.actualizarReserva.mockReturnValue(throwError(() => errorResponse));
-      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => { });
-
       component['actualizarReserva'](reserva);
 
-      expect(consoleSpy).toHaveBeenCalledWith('Error:', errorResponse);
+      expect(loggingService.error).toHaveBeenCalledWith('Error:', errorResponse);
       expect(toastr.error).toHaveBeenCalledWith('Ocurrió un error al actualizar la reserva', 'Error');
-
-      consoleSpy.mockRestore();
     });
   });
 

--- a/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.ts
+++ b/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.ts
@@ -4,6 +4,7 @@ import { ReservaService } from '../../../../core/services/reserva.service';
 import { Reserva } from '../../../../shared/models/reserva.model';
 import { ToastrService } from 'ngx-toastr';
 import { estadoReserva } from '../../../../shared/constants';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 @Component({
   selector: 'app-reservas-del-dia',
@@ -16,7 +17,7 @@ export class ReservasDelDiaComponent implements OnInit {
   reservas: Reserva[] = [];
   fechaHoy: string = '';
 
-  constructor(private reservaService: ReservaService, private toastr: ToastrService) { }
+  constructor(private reservaService: ReservaService, private toastr: ToastrService, private logger: LoggingService) { }
 
   ngOnInit(): void {
     this.consultarReservasDelDia();
@@ -71,7 +72,7 @@ export class ReservasDelDiaComponent implements OnInit {
         this.toastr.success(`Reserva marcada como ${reserva.estadoReserva}`, 'Actualización Exitosa');
       },
       error: (error) => {
-        console.log('Error:', error);
+        this.logger.error('Error:', error);
         this.toastr.error('Ocurrió un error al actualizar la reserva', 'Error');
       }
     });

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
@@ -8,6 +8,7 @@ import { ModalService } from '../../../../core/services/modal.service';
 import { ToastrService } from 'ngx-toastr';
 import { estadoPago } from '../../../../shared/constants';
 import { mockDomicilioRespone } from './../../../../shared/mocks/domicilio.mock';
+import { LoggingService } from '../../../../core/services/logging.service';
 
 describe('RutaDomicilioComponent', () => {
   let component: RutaDomicilioComponent;
@@ -17,6 +18,7 @@ describe('RutaDomicilioComponent', () => {
   let domicilioService: jest.Mocked<DomicilioService>;
   let modalService: jest.Mocked<ModalService>;
   let toastrService: jest.Mocked<ToastrService>;
+  let loggingService: jest.Mocked<LoggingService>;
 
   // Simulación de queryParams
   const queryParamsMock = {
@@ -58,6 +60,11 @@ describe('RutaDomicilioComponent', () => {
       error: jest.fn()
     };
 
+    const loggingServiceMock = {
+      log: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<LoggingService>;
+
     const routerMock = {
       navigate: jest.fn()
     };
@@ -71,6 +78,7 @@ describe('RutaDomicilioComponent', () => {
         { provide: DomicilioService, useValue: domicilioServiceMock },
         { provide: ModalService, useValue: modalServiceMock },
         { provide: ToastrService, useValue: toastrServiceMock },
+        { provide: LoggingService, useValue: loggingServiceMock },
         { provide: Router, useValue: routerMock }
       ]
     }).compileComponents();
@@ -81,6 +89,7 @@ describe('RutaDomicilioComponent', () => {
     domicilioService = TestBed.inject(DomicilioService) as jest.Mocked<DomicilioService>;
     modalService = TestBed.inject(ModalService) as jest.Mocked<ModalService>;
     toastrService = TestBed.inject(ToastrService) as jest.Mocked<ToastrService>;
+    loggingService = TestBed.inject(LoggingService) as jest.Mocked<LoggingService>;
     router = TestBed.inject(Router) as jest.Mocked<Router>;
 
     component.ngOnInit();

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -8,6 +8,7 @@ import { estadoPago } from '../../../../shared/constants';
 import { ModalService } from '../../../../core/services/modal.service';
 import { ToastrService } from 'ngx-toastr';
 import { SafePipe } from "../../../../shared/pipes/safe.pipe";
+import { LoggingService } from '../../../../core/services/logging.service';
 
 @Component({
   selector: 'app-ruta-domicilio',
@@ -32,7 +33,8 @@ export class RutaDomicilioComponent implements OnInit {
     public domicilioService: DomicilioService,
     public router: Router,
     public modalService: ModalService,
-    public toastrService: ToastrService
+    public toastrService: ToastrService,
+    private logger: LoggingService
   ) { }
 
   ngOnInit(): void {
@@ -69,7 +71,7 @@ export class RutaDomicilioComponent implements OnInit {
         .subscribe(
           response => {
             this.toastrService.success('Domicilio marcado como finalizado');
-            console.log('Domicilio marcado como finalizado', response);
+            this.logger.log('Domicilio marcado como finalizado', response);
           },
           error => {
             console.error('Error al marcar finalizado', error);
@@ -101,7 +103,7 @@ export class RutaDomicilioComponent implements OnInit {
               const modalData = this.modalService.getModalData();
               if (modalData.select?.selected) {
                 const metodoPagoSeleccionado = modalData.select.selected;
-                console.log('Método de pago seleccionado:', metodoPagoSeleccionado);
+                this.logger.log('Método de pago seleccionado:', metodoPagoSeleccionado);
                 this.domicilioService.updateDomicilio(this.domicilioId, {
                   estadoPago: estadoPago.PAGADO
                 }).subscribe(

--- a/src/app/shared/components/footer/footer.component.spec.ts
+++ b/src/app/shared/components/footer/footer.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { RestauranteService } from '../../../core/services/restaurante.service';
 import { of, throwError } from 'rxjs';
 import { mockCambioHorarioResponse, mockCambioHorarioAbiertoResponse, mockRestauranteResponse } from '../../mocks/restaurante.mock';
+import { LoggingService } from '../../../core/services/logging.service';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -17,6 +18,7 @@ describe('FooterComponent', () => {
   let component: FooterComponent;
   let fixture: ComponentFixture<FooterComponent>;
   let restauranteService: jest.Mocked<RestauranteService>;
+  let loggingService: jest.Mocked<LoggingService>;
 
   const mockError = new Error('Test error');
 
@@ -26,10 +28,16 @@ describe('FooterComponent', () => {
       getCambiosHorario: jest.fn()
     };
 
+    const loggingServiceMock = {
+      log: jest.fn(),
+      error: jest.fn()
+    } as unknown as jest.Mocked<LoggingService>;
+
     await TestBed.configureTestingModule({
       imports: [FooterComponent],
       providers: [
         { provide: RestauranteService, useValue: restauranteServiceMock },
+        { provide: LoggingService, useValue: loggingServiceMock },
         HttpClient,
         HttpHandler
       ]
@@ -38,6 +46,7 @@ describe('FooterComponent', () => {
     fixture = TestBed.createComponent(FooterComponent);
     component = fixture.componentInstance;
     restauranteService = TestBed.inject(RestauranteService) as jest.Mocked<RestauranteService>;
+    loggingService = TestBed.inject(LoggingService) as jest.Mocked<LoggingService>;
 
     restauranteService.getRestauranteInfo.mockReturnValue(of(mockRestauranteResponse));
   });
@@ -77,13 +86,10 @@ describe('FooterComponent', () => {
   });
 
   it('should log an error when getCambiosHorario fails', () => {
-    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
-
     restauranteService.getCambiosHorario.mockReturnValue(throwError(() => mockError));
     fixture.detectChanges();
 
-    expect(consoleSpy).toHaveBeenCalledWith(mockError);
-    consoleSpy.mockRestore();
+    expect(loggingService.error).toHaveBeenCalledWith(mockError);
   });
   it('should set estadoActual to "Cerrado" when current time is outside of opening hours', () => {
     restauranteService.getRestauranteInfo.mockReturnValue(of(mockRestauranteResponse));

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -3,6 +3,7 @@ import { Restaurante } from '../../models/restaurante.model';
 import { CambioHorario } from '../../models/cambio-horario.model';
 import { ApiResponse } from '../../models/api-response.model';
 import { RestauranteService } from '../../../core/services/restaurante.service';
+import { LoggingService } from '../../../core/services/logging.service';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -21,7 +22,7 @@ export class FooterComponent {
   estado: string = 'Abierto';
   estadoActual: string = 'Abierto';
 
-  constructor(private restauranteService: RestauranteService, private router: Router) { }
+  constructor(private restauranteService: RestauranteService, private router: Router, private logger: LoggingService) { }
 
   ngOnInit(): void {
     this.restauranteService.getRestauranteInfo().subscribe((response: ApiResponse<Restaurante>) => {
@@ -46,7 +47,7 @@ export class FooterComponent {
         }
         this.cambioHorario = response;
       },
-      error: (error) => { console.log(error); },
+      error: (error) => { this.logger.error(error); },
     });
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,6 @@ app.get('**', (req, res, next) => {
 if (isMainModule(import.meta.url)) {
   const port = process.env['PORT'] || 4000;
   app.listen(port, () => {
-    console.log(`Node Express server listening on http://localhost:${port}`);
+    console.info(`Node Express server listening on http://localhost:${port}`);
   });
 }


### PR DESCRIPTION
## Summary
- add shared `LoggingService` for unified logging
- replace `console.log` calls with `LoggingService` or `toastr` errors across modules
- switch server startup message to `console.info`

## Testing
- `npm test`
- `rg "console\.log" -n`


------
https://chatgpt.com/codex/tasks/task_e_68a28453790483259b4aceda2797f6dd