### PR TITLE
feat: extract checkout logic into dedicated service

### DIFF
--- a/src/app/core/services/checkout.service.spec.ts
+++ b/src/app/core/services/checkout.service.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { CheckoutService } from './checkout.service';
+import { CartService } from './cart.service';
+import { DomicilioService } from './domicilio.service';
+import { PedidoService } from './pedido.service';
+import { ProductoPedidoService } from './producto-pedido.service';
+import { PedidoClienteService } from './pedido-cliente.service';
+import { UserService } from './user.service';
+import { ClienteService } from './cliente.service';
+import { Router } from '@angular/router';
+
+describe('CheckoutService', () => {
+  let service: CheckoutService;
+  let cartServiceMock: any;
+  let domicilioServiceMock: any;
+  let pedidoServiceMock: any;
+  let productoPedidoServiceMock: any;
+  let pedidoClienteServiceMock: any;
+  let userServiceMock: any;
+  let clienteServiceMock: any;
+  let routerMock: any;
+
+  beforeEach(() => {
+    cartServiceMock = {
+      getItems: jest.fn(),
+      clearCart: jest.fn()
+    };
+    domicilioServiceMock = { createDomicilio: jest.fn() };
+    pedidoServiceMock = {
+      createPedido: jest.fn(),
+      assignPago: jest.fn(),
+      assignDomicilio: jest.fn()
+    };
+    productoPedidoServiceMock = { create: jest.fn() };
+    pedidoClienteServiceMock = { create: jest.fn() };
+    userServiceMock = { getUserId: jest.fn() };
+    clienteServiceMock = { getClienteId: jest.fn() };
+    routerMock = { navigate: jest.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        CheckoutService,
+        { provide: CartService, useValue: cartServiceMock },
+        { provide: DomicilioService, useValue: domicilioServiceMock },
+        { provide: PedidoService, useValue: pedidoServiceMock },
+        { provide: ProductoPedidoService, useValue: productoPedidoServiceMock },
+        { provide: PedidoClienteService, useValue: pedidoClienteServiceMock },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: ClienteService, useValue: clienteServiceMock },
+        { provide: Router, useValue: routerMock }
+      ]
+    });
+
+    service = TestBed.inject(CheckoutService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should finalize order without delivery', done => {
+    cartServiceMock.getItems.mockReturnValue([{ productoId: 1, nombre: 'P', cantidad: 2, precio: 10 }]);
+    userServiceMock.getUserId.mockReturnValue(5);
+    pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 1 } }));
+    productoPedidoServiceMock.create.mockReturnValue(of({}));
+    pedidoClienteServiceMock.create.mockReturnValue(of({}));
+    pedidoServiceMock.assignPago.mockReturnValue(of({}));
+    pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
+
+    service.checkout(2, false).subscribe({
+      next: () => {
+        expect(pedidoServiceMock.assignDomicilio).not.toHaveBeenCalled();
+        expect(cartServiceMock.clearCart).toHaveBeenCalled();
+        expect(routerMock.navigate).toHaveBeenCalledWith(['/cliente/mis-pedidos']);
+        done();
+      },
+      error: done.fail
+    });
+  });
+
+  it('should create domicilio and finalize order when delivery is needed', done => {
+    cartServiceMock.getItems.mockReturnValue([{ productoId: 1, nombre: 'P', cantidad: 1, precio: 10 }]);
+    userServiceMock.getUserId.mockReturnValue(10);
+    clienteServiceMock.getClienteId.mockReturnValue(of({ data: { direccion: 'dir', telefono: 'tel', observaciones: '' } }));
+    domicilioServiceMock.createDomicilio.mockReturnValue(of({ data: { domicilioId: 9 } }));
+    pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 2 } }));
+    productoPedidoServiceMock.create.mockReturnValue(of({}));
+    pedidoClienteServiceMock.create.mockReturnValue(of({}));
+    pedidoServiceMock.assignPago.mockReturnValue(of({}));
+    pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
+
+    service.checkout(1, true).subscribe({
+      next: () => {
+        expect(clienteServiceMock.getClienteId).toHaveBeenCalledWith(10);
+        expect(domicilioServiceMock.createDomicilio).toHaveBeenCalled();
+        expect(pedidoServiceMock.assignDomicilio).toHaveBeenCalledWith(2, 9);
+        done();
+      },
+      error: done.fail
+    });
+  });
+
+  it('should propagate error when client data retrieval fails', done => {
+    userServiceMock.getUserId.mockReturnValue(20);
+    clienteServiceMock.getClienteId.mockReturnValue(throwError(() => new Error('fail')));
+
+    service.checkout(1, true).subscribe({
+      next: () => done.fail('should error'),
+      error: () => {
+        expect(cartServiceMock.clearCart).not.toHaveBeenCalled();
+        expect(routerMock.navigate).not.toHaveBeenCalled();
+        done();
+      }
+    });
+  });
+});
+

--- a/src/app/core/services/checkout.service.ts
+++ b/src/app/core/services/checkout.service.ts
@@ -1,0 +1,124 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { of, throwError, Observable } from 'rxjs';
+import { switchMap, catchError, tap, map } from 'rxjs/operators';
+
+import { CartService } from './cart.service';
+import { DomicilioService } from './domicilio.service';
+import { PedidoService } from './pedido.service';
+import { ProductoPedidoService } from './producto-pedido.service';
+import { PedidoClienteService } from './pedido-cliente.service';
+import { UserService } from './user.service';
+import { ClienteService } from './cliente.service';
+
+import { Producto } from '../../shared/models/producto.model';
+import { Domicilio } from '../../shared/models/domicilio.model';
+import { Cliente } from '../../shared/models/cliente.model';
+import { estadoPago } from '../../shared/constants';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CheckoutService {
+  constructor(
+    private cart: CartService,
+    private domicilioService: DomicilioService,
+    private pedidoService: PedidoService,
+    private productoPedidoService: ProductoPedidoService,
+    private pedidoClienteService: PedidoClienteService,
+    private userService: UserService,
+    private clienteService: ClienteService,
+    private router: Router
+  ) {}
+
+  checkout(methodId: number, needsDelivery: boolean): Observable<void> {
+    if (!needsDelivery) {
+      return this.finalizeOrder(methodId, null);
+    }
+
+    const clienteId = this.userService.getUserId();
+    return this.clienteService.getClienteId(clienteId).pipe(
+      catchError(err => {
+        console.error('Error al obtener datos del cliente:', err);
+        return throwError(() => err);
+      }),
+      switchMap(resCliente => {
+        if (!resCliente || !resCliente.data) {
+          return throwError(() => new Error('No se pudo obtener la información del cliente'));
+        }
+        const cliente: Cliente = resCliente.data;
+
+        const hoy = new Date();
+        const yyyy = hoy.getFullYear();
+        const mm = String(hoy.getMonth() + 1).padStart(2, '0');
+        const dd = String(hoy.getDate()).padStart(2, '0');
+        const fechaHoy = `${yyyy}-${mm}-${dd}`;
+
+        const nuevoDomicilio: Domicilio = {
+          direccion: cliente.direccion,
+          telefono: cliente.telefono,
+          estadoPago: estadoPago.PENDIENTE,
+          entregado: false,
+          fechaDomicilio: fechaHoy,
+          observaciones: cliente.observaciones || '',
+          createdBy: `Usuario ${clienteId}`
+        };
+
+        return this.domicilioService.createDomicilio(nuevoDomicilio).pipe(
+          catchError(err2 => {
+            console.error('Error al crear domicilio:', err2);
+            return throwError(() => err2);
+          }),
+          switchMap(respDom => {
+            const domicilioId = (respDom.data as Domicilio).domicilioId!;
+            return this.finalizeOrder(methodId, domicilioId);
+          })
+        );
+      })
+    );
+  }
+
+  private finalizeOrder(methodId: number, domicilioId: number | null): Observable<void> {
+    const carrito: Producto[] = this.cart.getItems();
+    return this.pedidoService.createPedido({ delivery: domicilioId !== null }).pipe(
+      switchMap(res => {
+        const pedidoId = res.data.pedidoId!;
+        const detalles = carrito.map(p => ({
+          PK_ID_PRODUCTO: p.productoId!,
+          NOMBRE: p.nombre,
+          CANTIDAD: p.cantidad!,
+          PRECIO_UNITARIO: p.precio,
+          SUBTOTAL: p.precio * p.cantidad!
+        }));
+        return this.productoPedidoService.create({
+          PK_ID_PEDIDO: pedidoId,
+          DETALLES_PRODUCTOS: detalles
+        }).pipe(switchMap(() => of(pedidoId)));
+      }),
+      switchMap(pedidoId =>
+        this.pedidoClienteService.create({
+          pedidoId,
+          documentoCliente: this.userService.getUserId()
+        }).pipe(switchMap(() => of(pedidoId)))
+      ),
+      switchMap(pedidoId =>
+        this.pedidoService.assignPago(pedidoId, methodId).pipe(switchMap(() => of(pedidoId)))
+      ),
+      switchMap(pedidoId => {
+        return domicilioId !== null
+          ? this.pedidoService.assignDomicilio(pedidoId, domicilioId).pipe(switchMap(() => of(pedidoId)))
+          : of(pedidoId);
+      }),
+      tap(() => {
+        this.cart.clearCart();
+        this.router.navigate(['/cliente/mis-pedidos']);
+      }),
+      catchError(err => {
+        console.error('Error en el flujo de finalizeOrder:', err);
+        return throwError(() => err);
+      }),
+      map(() => void 0)
+    );
+  }
+}
+

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -2,25 +2,15 @@
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Subscription, of } from 'rxjs';
-import { switchMap, catchError } from 'rxjs/operators';
-import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 
 import { CartService } from '../../../core/services/cart.service';
 import { ModalService } from '../../../core/services/modal.service';
 import { MetodosPagoService } from '../../../core/services/metodos-pago.service';
-import { DomicilioService } from '../../../core/services/domicilio.service';
-import { PedidoService } from '../../../core/services/pedido.service';
-import { ProductoPedidoService } from '../../../core/services/producto-pedido.service';
-import { PedidoClienteService } from '../../../core/services/pedido-cliente.service';
-import { UserService } from '../../../core/services/user.service';
-import { ClienteService } from '../../../core/services/cliente.service';
+import { CheckoutService } from '../../../core/services/checkout.service';
 
 import { Producto } from '../../../shared/models/producto.model';
 import { MetodosPago } from '../../../shared/models/metodo-pago.model';
-import { Domicilio } from '../../../shared/models/domicilio.model';
-import { Cliente } from '../../../shared/models/cliente.model';
-import { estadoPago } from '../../../shared/constants';
 
 @Component({
   selector: 'app-carrito',
@@ -41,13 +31,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
     private cart: CartService,
     private modalService: ModalService,
     private metodosPagoService: MetodosPagoService,
-    private domicilioService: DomicilioService,
-    private pedidoService: PedidoService,
-    private productoPedidoService: ProductoPedidoService,
-    private pedidoClienteService: PedidoClienteService,
-    private userService: UserService,
-    private clienteService: ClienteService, // Ya existe en tu proyecto
-    private router: Router
+    private checkoutService: CheckoutService
   ) { }
 
   ngOnInit(): void {
@@ -99,119 +83,14 @@ export class CarritoComponent implements OnInit, OnDestroy {
   private onCheckoutConfirm() {
     const { selects } = this.modalService.getModalData();
     const [methodSelect, deliverySelect] = selects;
-    const methodId      = methodSelect.selected as number;
+    const methodId = methodSelect.selected as number;
     const needsDelivery = deliverySelect.selected as boolean;
 
     this.modalService.closeModal();
 
-    // 1) Si NO requiere domicilio → finalizamos sin crear domicilio
-    if (!needsDelivery) {
-      return this.finalizeOrder(methodId, null);
-    }
-
-    // 2) Si requiere domicilio:
-    //    2.1) Obtenemos el ID del cliente (documento) desde el token
-    const clienteId = this.userService.getUserId();
-
-    //    2.2) Llamamos a ClienteService.getClienteId(...) para traer su registro completo
-    this.clienteService.getClienteId(clienteId).pipe(
-      catchError(err => {
-        console.error('Error al obtener datos del cliente:', err);
-        // En caso de error, retornamos null para interrumpir el flujo
-        return of(null as any);
-      }),
-      switchMap((resCliente) => {
-        if (!resCliente || !resCliente.data) {
-          throw new Error('No se pudo obtener la información del cliente');
-        }
-        const cliente: Cliente = resCliente.data;
-
-        // 2.3) Creamos el objeto Domicilio con la dirección/telefono que trae el cliente
-        const hoy = new Date();
-        const yyyy = hoy.getFullYear();
-        const mm   = String(hoy.getMonth() + 1).padStart(2, '0');
-        const dd   = String(hoy.getDate()).padStart(2, '0');
-        const fechaHoy = `${yyyy}-${mm}-${dd}`; // formato "YYYY-MM-DD"
-
-        const nuevoDomicilio: Domicilio = {
-          direccion:      cliente.direccion,
-          telefono:       cliente.telefono,
-          estadoPago:     estadoPago.PENDIENTE,   // Asignamos 'PENDIENTE' por defecto
-          entregado:      false,         // Recién creado
-          fechaDomicilio: fechaHoy,
-          observaciones:  cliente.observaciones || '',
-          createdBy:      `Usuario ${clienteId}`, // Asignamos el ID del cliente como creador
-          // createdAt/updatedAt los maneja el backend; trabajadorAsignado=null
-        };
-
-        // 2.4) Llamamos a createDomicilio para insertarlo en la BD
-        return this.domicilioService.createDomicilio(nuevoDomicilio).pipe(
-          catchError(err2 => {
-            console.error('Error al crear domicilio:', err2);
-            throw err2;
-          })
-        );
-      })
-    ).subscribe({
-      next: (respDomicilio) => {
-        // 2.5) Ya tenemos el domicilio recién creado → extraemos domicilioId
-        const domicilioId = (respDomicilio.data as Domicilio).domicilioId!;
-        // 2.6) Continuamos el flujo normal con finalizeOrder
-        this.finalizeOrder(methodId, domicilioId);
-      },
-      error: (err) => {
-        // Si algo falla al obtener cliente o crear domicilio → mostramos un error
-        console.error('No se pudo completar la creación de domicilio, el checkout se canceló.', err);
-        // Aquí podrías mostrar un toast o mensaje en pantalla para avisar al usuario
-      }
-    });
-  }
-
-  private finalizeOrder(methodId: number, domicilioId: number | null) {
-    // 3.1) Crear el pedido (POST /pedidos) → devolvemos el ID
-    this.pedidoService.createPedido({ delivery: domicilioId !== null }).pipe(
-      switchMap(res => {
-        const pedidoId = res.data.pedidoId!;
-
-        // 3.2) Crear ProductoPedido (POST /producto_pedido)
-        const detalles = this.carrito.map(p => ({
-          PK_ID_PRODUCTO:   p.productoId!,
-          NOMBRE:           p.nombre,
-          CANTIDAD:         p.cantidad!,
-          PRECIO_UNITARIO:  p.precio,
-          SUBTOTAL:         p.precio * p.cantidad!
-        }));
-        return this.productoPedidoService.create({
-          PK_ID_PEDIDO:       pedidoId,
-          DETALLES_PRODUCTOS: detalles
-        }).pipe(switchMap(() => of(pedidoId)));
-      }),
-      // 3.3) Crear PedidoCliente (POST /pedido_clientes)
-      switchMap(pedidoId =>
-        this.pedidoClienteService.create({
-          pedidoId:         pedidoId,
-          documentoCliente: this.userService.getUserId()
-        }).pipe(switchMap(() => of(pedidoId)))
-      ),
-      // 3.4) Asignar pago (POST /pedidos/asignar-pago?pedido_id=X&pago_id=Y)
-      switchMap(pedidoId =>
-        this.pedidoService.assignPago(pedidoId, methodId).pipe(switchMap(() => of(pedidoId)))
-      ),
-      // 3.5) Si existe domicilioId, asignarlo (POST /pedidos/asignar-domicilio?pedido_id=X&domicilio_id=Y)
-      switchMap(pedidoId => {
-        return domicilioId !== null
-          ? this.pedidoService.assignDomicilio(pedidoId, domicilioId)
-          : of(null);
-      })
-    ).subscribe({
-      next: () => {
-        // 3.6) Al terminar, limpio carrito y redirijo a “Mis pedidos”
-        this.cart.clearCart();
-        this.router.navigate(['/cliente/mis-pedidos']);
-      },
+    this.checkoutService.checkout(methodId, needsDelivery).subscribe({
       error: err => {
-        console.error('Error en el flujo de finalizeOrder:', err);
-        // Aquí podrías mostrar un toast de error
+        console.error('Error en el proceso de checkout:', err);
       }
     });
   }


### PR DESCRIPTION
## Summary
- extract checkout and domicilio creation flow to new CheckoutService
- simplify CarritoComponent to delegate checkout to service
- add unit tests for CheckoutService covering success and error paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2875e14088325b97078327bcddaf7