### PR TITLE
feat: add typed modal data interface

### DIFF
--- a/src/app/core/services/modal.service.spec.ts
+++ b/src/app/core/services/modal.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { ModalService } from './modal.service';
+import { ModalData } from '../../shared/models/modal-data.model';
 
 describe('ModalService', () => {
   let service: ModalService;
@@ -24,7 +25,7 @@ describe('ModalService', () => {
   });
 
   it('should update modalData and set isOpen to true when openModal is called', () => {
-    const data = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const data: ModalData = { title: 'Test Modal', message: 'Contenido de prueba' };
     service.openModal(data);
 
     expect(service.getModalData()).toEqual(data);

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -1,16 +1,17 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { ModalData } from '../../shared/models/modal-data.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ModalService {
-  private modalData = new BehaviorSubject<any>(null);
+  private modalData = new BehaviorSubject<ModalData | null>(null);
   modalData$ = this.modalData.asObservable();
   private isOpen = new BehaviorSubject<boolean>(false);
   isOpen$ = this.isOpen.asObservable();
 
-  openModal(data: any) {
+  openModal(data: ModalData) {
     console.log('Entra');
     this.modalData.next(data);
     this.isOpen.next(true);
@@ -19,8 +20,8 @@ export class ModalService {
   closeModal() {
     this.isOpen.next(false);
   }
-  getModalData(): any {
-    console.log('getModalData')
+  getModalData(): ModalData | null {
+    console.log('getModalData');
     return this.modalData.value;
   }
   

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -97,7 +97,9 @@ export class CarritoComponent implements OnInit, OnDestroy {
   }
 
   private onCheckoutConfirm() {
-    const { selects } = this.modalService.getModalData();
+    const modalData = this.modalService.getModalData();
+    const selects = modalData?.selects;
+    if (!selects) return;
     const [methodSelect, deliverySelect] = selects;
     const methodId      = methodSelect.selected as number;
     const needsDelivery = deliverySelect.selected as boolean;

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.spec.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.spec.ts
@@ -187,7 +187,11 @@ describe('ConsultarDomicilioComponent', () => {
       ]));
       let modalConfig: any;
       modalService.openModal.mockImplementation(config => (modalConfig = config));
-      modalService.getModalData.mockReturnValue({ select: { selected: 1 } });
+      modalService.getModalData.mockReturnValue({
+        title: '',
+        selects: [{ label: '', options: [], selected: 1 }],
+        buttons: []
+      });
       jest.spyOn(component, 'confirmarAsignacion');
       domicilioService.asignarDomiciliario.mockReturnValue(of({ code: 200 }));
       trabajadorService.searchTrabajador.mockReturnValue(of({ data: { nombre: 'A', apellido: 'B' } }));
@@ -208,7 +212,11 @@ describe('ConsultarDomicilioComponent', () => {
       ]));
       let modalConfig: any;
       modalService.openModal.mockImplementation(config => (modalConfig = config));
-      modalService.getModalData.mockReturnValue({ select: { selected: null } });
+      modalService.getModalData.mockReturnValue({
+        title: '',
+        selects: [{ label: '', options: [], selected: null }],
+        buttons: []
+      });
       jest.spyOn(component, 'confirmarAsignacion');
 
       component.asignarDomicilio(domicilioBase);

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
@@ -77,19 +77,22 @@ export class ConsultarDomicilioComponent implements OnInit {
 
       this.modalService.openModal({
         title: 'Asignar Trabajador',
-        select: {
-          label: 'Seleccione un trabajador',
-          options: trabajadoresOptions,
-          selected: null
-        },
+        selects: [
+          {
+            label: 'Seleccione un trabajador',
+            options: trabajadoresOptions,
+            selected: null
+          }
+        ],
         buttons: [
           {
             label: 'Aceptar',
             class: 'btn btn-success',
             action: () => {
               const modalData = this.modalService.getModalData();
-              if (modalData.select?.selected) {
-                this.confirmarAsignacion(domicilio, modalData.select.selected);
+              const selected = modalData?.selects?.[0].selected;
+              if (selected) {
+                this.confirmarAsignacion(domicilio, selected);
                 this.modalService.closeModal();
               }
             }

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
@@ -116,7 +116,9 @@ describe('RutaDomicilioComponent', () => {
   describe('marcarPago', () => {
     it('should open modal and process payment when a method is selected', () => {
       modalService.getModalData.mockReturnValue({
-        select: { selected: 'NEQUI' }
+        title: '',
+        selects: [{ label: '', options: [], selected: 'NEQUI' }],
+        buttons: []
       });
       domicilioService.updateDomicilio.mockReturnValue(of(mockDomicilioRespone));
 
@@ -134,7 +136,9 @@ describe('RutaDomicilioComponent', () => {
 
     it('should log error when no payment method is selected', () => {
       modalService.getModalData.mockReturnValue({
-        select: { selected: null }
+        title: '',
+        selects: [{ label: '', options: [], selected: null }],
+        buttons: []
       });
       console.error = jest.fn();
       component.marcarPago();
@@ -145,7 +149,9 @@ describe('RutaDomicilioComponent', () => {
 
     it('should handle error when updating domicilio payment fails', () => {
       modalService.getModalData.mockReturnValue({
-        select: { selected: 'DAVIPLATA' }
+        title: '',
+        selects: [{ label: '', options: [], selected: 'DAVIPLATA' }],
+        buttons: []
       });
       const errorResponse = new Error('Error');
       domicilioService.updateDomicilio.mockReturnValue(throwError(() => errorResponse));
@@ -157,7 +163,9 @@ describe('RutaDomicilioComponent', () => {
 
     it('should close modal when cancel button is clicked', () => {
       modalService.getModalData.mockReturnValue({
-        select: { selected: 'NEQUI' }
+        title: '',
+        selects: [{ label: '', options: [], selected: 'NEQUI' }],
+        buttons: []
       });
       component.marcarPago();
       const config = modalService.openModal.mock.calls[0][0];

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -84,23 +84,26 @@ export class RutaDomicilioComponent implements OnInit {
     if (this.domicilioId) {
       this.modalService.openModal({
         title: 'Seleccionar Método de Pago',
-        select: {
-          label: 'Seleccione el método de pago',
-          options: [
-            { label: 'Nequi', value: 'NEQUI' },
-            { label: 'Daviplata', value: 'DAVIPLATA' },
-            { label: 'Efectivo', value: 'EFECTIVO' }
-          ],
-          selected: null
-        },
+        selects: [
+          {
+            label: 'Seleccione el método de pago',
+            options: [
+              { label: 'Nequi', value: 'NEQUI' },
+              { label: 'Daviplata', value: 'DAVIPLATA' },
+              { label: 'Efectivo', value: 'EFECTIVO' }
+            ],
+            selected: null
+          }
+        ],
         buttons: [
           {
             label: 'Aceptar',
             class: 'btn btn-success',
             action: () => {
               const modalData = this.modalService.getModalData();
-              if (modalData.select?.selected) {
-                const metodoPagoSeleccionado = modalData.select.selected;
+              const selected = modalData?.selects?.[0].selected;
+              if (selected) {
+                const metodoPagoSeleccionado = selected;
                 console.log('Método de pago seleccionado:', metodoPagoSeleccionado);
                 this.domicilioService.updateDomicilio(this.domicilioId, {
                   estadoPago: estadoPago.PAGADO

--- a/src/app/shared/components/modal/modal.component.html
+++ b/src/app/shared/components/modal/modal.component.html
@@ -1,17 +1,17 @@
 <div class="modal-overlay" *ngIf="isOpen" (click)="close()">
     <div class="modal-content" (click)="$event.stopPropagation()">
         <div class="modal-header">
-            <h2 *ngIf="modalData.title">{{ modalData.title }}</h2>
+            <h2 *ngIf="modalData?.title">{{ modalData?.title }}</h2>
             <button class="close-btn" (click)="close()">&times;</button>
         </div>
 
         <div class="modal-body">
-            <img *ngIf="modalData.image" [src]="modalData.image" alt="Imagen modal" />
+            <img *ngIf="modalData?.image" [src]="modalData?.image" alt="Imagen modal" />
 
-            <div class="mt-3" *ngIf="modalData.message" [innerHTML]="modalData.message"></div>
+            <div class="mt-3" *ngIf="modalData?.message" [innerHTML]="modalData?.message"></div>
 
-            <ng-container *ngIf="modalData.selects">
-                <div *ngFor="let sel of modalData.selects" class="form-group mt-3">
+            <ng-container *ngIf="modalData?.selects">
+                <div *ngFor="let sel of modalData?.selects || []" class="form-group mt-3">
                     <label>{{ sel.label }}</label>
                     <select class="form-control" [(ngModel)]="sel.selected">
                         <option *ngFor="let o of sel.options" [ngValue]="o.value">
@@ -20,19 +20,10 @@
                     </select>
                 </div>
             </ng-container>
-
-            <div *ngIf="modalData.select">
-                <label>{{ modalData.select.label }}</label>
-                <select class="form-control" [(ngModel)]="modalData.select.selected">
-                    <option *ngFor="let item of modalData.select.options" [value]="item.value">
-                        {{ item.label }}
-                    </option>
-                </select>
-            </div>
         </div>
 
-        <div class="modal-buttons" *ngIf="modalData.buttons">
-            <button *ngFor="let btn of modalData.buttons" (click)="btn.action()" [class]="btn.class">
+        <div class="modal-buttons" *ngIf="modalData?.buttons">
+            <button *ngFor="let btn of modalData?.buttons || []" (click)="btn.action()" [class]="btn.class">
                 {{ btn.label }}
             </button>
         </div>

--- a/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/app/shared/components/modal/modal.component.spec.ts
@@ -2,16 +2,17 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalComponent } from './modal.component';
 import { ModalService } from '../../../core/services/modal.service';
 import { BehaviorSubject } from 'rxjs';
+import { ModalData } from '../../models/modal-data.model';
 
 describe('ModalComponent', () => {
   let component: ModalComponent;
   let fixture: ComponentFixture<ModalComponent>;
   let modalServiceSpy: any;
-  let modalDataSubject: BehaviorSubject<any>;
+  let modalDataSubject: BehaviorSubject<ModalData | null>;
   let isOpenSubject: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
-    modalDataSubject = new BehaviorSubject(null);
+    modalDataSubject = new BehaviorSubject<ModalData | null>(null);
     isOpenSubject = new BehaviorSubject(false);
     modalServiceSpy = {
       modalData$: modalDataSubject.asObservable(),
@@ -36,7 +37,7 @@ describe('ModalComponent', () => {
   });
 
   it('should update modalData when modalService emits new data', () => {
-    const testData = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const testData: ModalData = { title: 'Test Modal', message: 'Contenido de prueba' };
     modalDataSubject.next(testData);
     fixture.detectChanges();
     expect(component.modalData).toEqual(testData);

--- a/src/app/shared/components/modal/modal.component.ts
+++ b/src/app/shared/components/modal/modal.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ModalService } from '../../../core/services/modal.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ModalData } from '../../models/modal-data.model';
 
 @Component({
   selector: 'app-modal',
@@ -12,15 +13,13 @@ import { FormsModule } from '@angular/forms';
 })
 export class ModalComponent implements OnInit {
   isOpen = false;
-  modalData: any = {};
+  modalData: ModalData | null = null;
 
   constructor(private modalService: ModalService) { }
 
   ngOnInit() {
     this.modalService.modalData$.subscribe((data) => {
-      if (data) {
-        this.modalData = data;
-      }
+      this.modalData = data;
     });
 
     this.modalService.isOpen$.subscribe((state) => {

--- a/src/app/shared/models/modal-data.model.ts
+++ b/src/app/shared/models/modal-data.model.ts
@@ -1,0 +1,24 @@
+export interface ModalOption {
+  label: string;
+  value: any;
+}
+
+export interface ModalSelect {
+  label: string;
+  options: ModalOption[];
+  selected: any;
+}
+
+export interface ModalButton {
+  label: string;
+  class: string;
+  action: () => void;
+}
+
+export interface ModalData {
+  title: string;
+  message?: string;
+  image?: File | string;
+  selects?: ModalSelect[];
+  buttons?: ModalButton[];
+}


### PR DESCRIPTION
## Summary
- add `ModalData` interface to describe modal configuration
- type `ModalService` and consumers to use `ModalData`
- replace single `select` with `selects` arrays across modal usage
- allow nullable modal fields and support `File` images

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm run lint:scss` *(fails: 434 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a287463ddc83259ee2b3d290c11d2f