### PR TITLE
feat: handle domicilio service errors

### DIFF
--- a/src/app/core/services/domicilio.service.spec.ts
+++ b/src/app/core/services/domicilio.service.spec.ts
@@ -6,16 +6,25 @@ import { environment } from '../../../environments/environment';
 import { Domicilio } from '../../shared/models/domicilio.model';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { estadoPago } from '../../shared/constants';
+import { HandleErrorService } from './handle-error.service';
 
 describe('DomicilioService', () => {
   let service: DomicilioService;
   let httpMock: HttpTestingController;
   const baseUrl = `${environment.apiUrl}/domicilios`;
 
+  const mockHandleErrorService = {
+    handleError: jest.fn((error: any) => { throw error; })
+  };
+
   beforeEach(() => {
+    mockHandleErrorService.handleError.mockReset();
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [DomicilioService]
+      providers: [
+        DomicilioService,
+        { provide: HandleErrorService, useValue: mockHandleErrorService }
+      ]
     });
     service = TestBed.inject(DomicilioService);
     httpMock = TestBed.inject(HttpTestingController);
@@ -44,6 +53,18 @@ describe('DomicilioService', () => {
       expect(req.request.method).toBe('GET');
       req.flush(mockResponse);
     });
+
+    it('should handle error when GET domicilios', () => {
+      const params = { filter: 'test' };
+      service.getDomicilios(params).subscribe({
+        error: (error) => {
+          expect(error).toBeTruthy();
+        }
+      });
+      const req = httpMock.expectOne(r => r.url === baseUrl && r.params.get('filter') === 'test');
+      req.error(new ErrorEvent('API error'));
+      expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+    });
   });
 
   describe('getDomicilioById', () => {
@@ -58,6 +79,18 @@ describe('DomicilioService', () => {
       const req = httpMock.expectOne(`${baseUrl}/search?id=${id}`);
       expect(req.request.method).toBe('GET');
       req.flush(mockResponse);
+    });
+
+    it('should handle error when GET domicilio by id', () => {
+      const id = 1;
+      service.getDomicilioById(id).subscribe({
+        error: (error) => {
+          expect(error).toBeTruthy();
+        }
+      });
+      const req = httpMock.expectOne(`${baseUrl}/search?id=${id}`);
+      req.error(new ErrorEvent('API error'));
+      expect(mockHandleErrorService.handleError).toHaveBeenCalled();
     });
   });
 
@@ -75,6 +108,17 @@ describe('DomicilioService', () => {
       expect(req.request.body).toEqual(newDomicilio);
       req.flush(mockResponse);
     });
+
+    it('should handle error when POST domicilio', () => {
+      service.createDomicilio(mockDomicilioBody).subscribe({
+        error: (error) => {
+          expect(error).toBeTruthy();
+        }
+      });
+      const req = httpMock.expectOne(baseUrl);
+      req.error(new ErrorEvent('API error'));
+      expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+    });
   });
 
   describe('updateDomicilio', () => {
@@ -91,6 +135,19 @@ describe('DomicilioService', () => {
       expect(req.request.method).toBe('PUT');
       expect(req.request.body).toEqual(updatedData);
       req.flush(mockResponse);
+    });
+
+    it('should handle error when PUT domicilio', () => {
+      const id = 1;
+      const updatedData: Partial<Domicilio> = { entregado: true };
+      service.updateDomicilio(id, updatedData).subscribe({
+        error: (error) => {
+          expect(error).toBeTruthy();
+        }
+      });
+      const req = httpMock.expectOne(`${baseUrl}?id=${id}`);
+      req.error(new ErrorEvent('API error'));
+      expect(mockHandleErrorService.handleError).toHaveBeenCalled();
     });
   });
 
@@ -111,6 +168,18 @@ describe('DomicilioService', () => {
       expect(req.request.method).toBe('DELETE');
       req.flush(mockResponse);
     });
+
+    it('should handle error when DELETE domicilio', () => {
+      const id = 1;
+      service.deleteDomicilio(id).subscribe({
+        error: (error) => {
+          expect(error).toBeTruthy();
+        }
+      });
+      const req = httpMock.expectOne(`${baseUrl}?id=${id}`);
+      req.error(new ErrorEvent('API error'));
+      expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+    });
   });
 
   describe('asignarDomiciliario', () => {
@@ -128,6 +197,20 @@ describe('DomicilioService', () => {
       expect(req.request.method).toBe('POST');
       expect(req.request.body).toEqual({});
       req.flush(mockResponse);
+    });
+
+    it('should handle error when POST asignar domiciliario', () => {
+      const domicilioId = 1;
+      const trabajadorId = 2;
+      service.asignarDomiciliario(domicilioId, trabajadorId).subscribe({
+        error: (error) => {
+          expect(error).toBeTruthy();
+        }
+      });
+      const expectedUrl = `${baseUrl}/asignar?domicilio_id=${domicilioId}&trabajador_id=${trabajadorId}`;
+      const req = httpMock.expectOne(expectedUrl);
+      req.error(new ErrorEvent('API error'));
+      expect(mockHandleErrorService.handleError).toHaveBeenCalled();
     });
   });
 });

--- a/src/app/core/services/domicilio.service.ts
+++ b/src/app/core/services/domicilio.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, catchError } from 'rxjs';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Domicilio } from '../../shared/models/domicilio.model';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +12,7 @@ import { environment } from '../../../environments/environment';
 export class DomicilioService {
   private baseUrl = `${environment.apiUrl}/domicilios`;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 
   /**
    * Obtiene todos los domicilios según filtros
@@ -19,7 +20,9 @@ export class DomicilioService {
    * @returns 
    */
   getDomicilios(params?: any): Observable<ApiResponse<Domicilio[]>> {
-    return this.http.get<ApiResponse<Domicilio[]>>(this.baseUrl, { params });
+    return this.http.get<ApiResponse<Domicilio[]>>(this.baseUrl, { params }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -27,7 +30,9 @@ export class DomicilioService {
    * @param id ID del domicilio
    */
   getDomicilioById(id: number): Observable<ApiResponse<Domicilio>> {
-    return this.http.get<ApiResponse<Domicilio>>(`${this.baseUrl}/search?id=${id}`);
+    return this.http.get<ApiResponse<Domicilio>>(`${this.baseUrl}/search?id=${id}`).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -35,7 +40,9 @@ export class DomicilioService {
    * @param domicilio Datos del domicilio a crear
    */
   createDomicilio(domicilio: Domicilio): Observable<ApiResponse<Domicilio>> {
-    return this.http.post<ApiResponse<Domicilio>>(this.baseUrl, domicilio);
+    return this.http.post<ApiResponse<Domicilio>>(this.baseUrl, domicilio).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -44,7 +51,9 @@ export class DomicilioService {
    * @param domicilio Datos actualizados
    */
   updateDomicilio(id: number, domicilio: Partial<Domicilio>): Observable<ApiResponse<Domicilio>> {
-    return this.http.put<ApiResponse<Domicilio>>(`${this.baseUrl}?id=${id}`, domicilio);
+    return this.http.put<ApiResponse<Domicilio>>(`${this.baseUrl}?id=${id}`, domicilio).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -52,7 +61,9 @@ export class DomicilioService {
    * @param id ID del domicilio
    */
   deleteDomicilio(id: number): Observable<ApiResponse<any>> {
-    return this.http.delete<ApiResponse<any>>(`${this.baseUrl}?id=${id}`);
+    return this.http.delete<ApiResponse<any>>(`${this.baseUrl}?id=${id}`).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
   /**
    * Asigna un domiciliario a un domicilio
@@ -63,6 +74,8 @@ export class DomicilioService {
     const params = new URLSearchParams();
     params.append('domicilio_id', domicilioId.toString());
     params.append('trabajador_id', trabajadorId.toString());
-    return this.http.post<ApiResponse<Domicilio>>(`${this.baseUrl}/asignar?${params.toString()}`, {});
+    return this.http.post<ApiResponse<Domicilio>>(`${this.baseUrl}/asignar?${params.toString()}`, {}).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 }


### PR DESCRIPTION
## Summary
- inject HandleErrorService into DomicilioService and handle HTTP errors via catchError
- extend DomicilioService tests to verify error handling paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28c6bc184832584c8bfebe70aa4c2