### PR TITLE
feat: add error handling to producto service

### DIFF
--- a/src/app/core/services/producto.service.spec.ts
+++ b/src/app/core/services/producto.service.spec.ts
@@ -2,16 +2,27 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ProductoService } from './producto.service';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 describe('ProductoService', () => {
   let service: ProductoService;
   let http: HttpTestingController;
   const baseUrl = `${environment.apiUrl}/productos`;
 
+  const mockHandleErrorService = {
+    handleError: jest.fn((error: any) => { throw error; })
+  };
+
   beforeEach(() => {
-    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: HandleErrorService, useValue: mockHandleErrorService }
+      ]
+    });
     service = TestBed.inject(ProductoService);
     http = TestBed.inject(HttpTestingController);
+    jest.clearAllMocks();
   });
 
   afterEach(() => http.verify());
@@ -55,5 +66,49 @@ describe('ProductoService', () => {
     expect(req.request.method).toBe('PUT');
     expect(req.request.body).toBe(form);
     req.flush(mock);
+  });
+
+  it('handles error on getProductos', () => {
+    service.getProductos().subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
+  it('handles error on createProducto', () => {
+    const form = new FormData();
+    service.createProducto(form).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
+  it('handles error on getProductoById', () => {
+    service.getProductoById(2).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}/search?id=2`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
+  it('handles error on updateProducto', () => {
+    const form = new FormData();
+    service.updateProducto(3, form).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}?id=3`);
+    expect(req.request.method).toBe('PUT');
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
   });
 });

--- a/src/app/core/services/producto.service.ts
+++ b/src/app/core/services/producto.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, catchError } from 'rxjs';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Producto } from '../../shared/models/producto.model';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +12,7 @@ import { environment } from '../../../environments/environment';
 export class ProductoService {
   private baseUrl = `${environment.apiUrl}/productos`;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 
   /**
    * Obtiene productos del backend y los mapea con nombres en minúsculas
@@ -19,7 +20,9 @@ export class ProductoService {
    * @returns 
    */
   getProductos(params?: any): Observable<ApiResponse<Producto[]>> {
-    return this.http.get<ApiResponse<Producto[]>>(`${this.baseUrl}`, { params });
+    return this.http.get<ApiResponse<Producto[]>>(`${this.baseUrl}`, { params }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -28,7 +31,9 @@ export class ProductoService {
    * @returns 
    */
   createProducto(formData: FormData): Observable<ApiResponse<Producto>> {
-    return this.http.post<ApiResponse<Producto>>(`${this.baseUrl}`, formData);
+    return this.http.post<ApiResponse<Producto>>(`${this.baseUrl}`, formData).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -37,7 +42,9 @@ export class ProductoService {
   getProductoById(id: number): Observable<ApiResponse<Producto>> {
     return this.http.get<ApiResponse<Producto>>(`${this.baseUrl}/search`, {
       params: { id: id.toString() }
-    });
+    }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   /**
@@ -46,7 +53,9 @@ export class ProductoService {
   updateProducto(id: number, formData: FormData): Observable<ApiResponse<Producto>> {
     return this.http.put<ApiResponse<Producto>>(`${this.baseUrl}`, formData, {
       params: { id: id.toString() }
-    });
+    }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
 }


### PR DESCRIPTION
## Summary
- inject HandleErrorService into ProductoService and use catchError in HTTP methods
- cover ProductoService error cases in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28c782c88832596a2a92fabc22272