### PR TITLE
refactor: type decoded token in user service

### DIFF
--- a/src/app/core/services/user.service.spec.ts
+++ b/src/app/core/services/user.service.spec.ts
@@ -100,11 +100,11 @@ describe('UserService', () => {
   });
 
   it('should decode token correctly', () => {
-    const tokenPayload = { rol: 'Administrador', exp: Math.floor(Date.now() / 1000) + 1000 };
+    const tokenPayload = { rol: 'Administrador', documento: 1, exp: Math.floor(Date.now() / 1000) + 1000 };
     const encodedPayload = btoa(JSON.stringify(tokenPayload));
     localStorage.setItem('auth_token', `header.${encodedPayload}.signature`);
     const decoded = service.decodeToken();
-    expect(decoded).toEqual({ rol: 'Administrador', exp: expect.any(Number) });
+    expect(decoded).toEqual({ rol: 'Administrador', documento: expect.any(Number), exp: expect.any(Number) });
   });
 
   it('should log an error and return null if token decoding fails', () => {
@@ -124,7 +124,7 @@ describe('UserService', () => {
   });
 
   it('should return user role if token is valid', () => {
-    const decodedToken = { rol: 'Administrador', exp: Math.floor(Date.now() / 1000) + 1000 };
+    const decodedToken = { rol: 'Administrador', documento: 1, exp: Math.floor(Date.now() / 1000) + 1000 };
     jest.spyOn(service, 'decodeToken').mockReturnValue(decodedToken);
     const result = service.getUserRole();
     expect(result).toBe('Administrador');
@@ -157,7 +157,7 @@ describe('UserService', () => {
   });
 
   it('should return true if decoded token does not have exp property', () => {
-    const decodedToken = { rol: 'Usuario' };
+    const decodedToken: any = { rol: 'Usuario', documento: 1 };
     jest.spyOn(service, 'decodeToken').mockReturnValue(decodedToken);
     const result = service.isTokenExpired();
     expect(result).toBe(true);

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -4,9 +4,14 @@ import { BehaviorSubject, Observable, catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Login, LoginResponse } from '../../shared/models/login.model';
-import { Cliente } from '../../shared/models/cliente.model';
-import { Trabajador } from '../../shared/models/trabajador.model';
 import { HandleErrorService } from './handle-error.service';
+
+export interface DecodedToken {
+  rol: string;
+  documento: number;
+  exp: number;
+  [key: string]: any;
+}
 
 @Injectable({
   providedIn: 'root',
@@ -45,13 +50,13 @@ export class UserService {
     return localStorage.getItem(this.tokenKey);
   }
 
-  decodeToken(): any {
+  decodeToken(): DecodedToken | null {
     const token = this.getToken();
     if (!token) return null;
 
     try {
       const payload = atob(token.split('.')[1]);
-      return JSON.parse(payload);
+      return JSON.parse(payload) as DecodedToken;
     } catch (error) {
       console.error('Error al decodificar el token:', error);
       return null;
@@ -59,17 +64,17 @@ export class UserService {
   }
 
   getUserRole(): string | null {
-    const decoded = this.decodeToken();
+    const decoded: DecodedToken | null = this.decodeToken();
     return decoded ? decoded.rol : null;
   }
 
   getUserId(): number {
-    const decoded = this.decodeToken();
+    const decoded: DecodedToken | null = this.decodeToken();
     return decoded ? decoded.documento : 0;
   }
 
   isTokenExpired(): boolean {
-    const decoded = this.decodeToken();
+    const decoded: DecodedToken | null = this.decodeToken();
     if (!decoded || !decoded.exp) return true;
 
     const currentTime = Math.floor(new Date().getTime() / 1000);

--- a/src/app/modules/client/perfil/perfil.component.spec.ts
+++ b/src/app/modules/client/perfil/perfil.component.spec.ts
@@ -31,7 +31,7 @@ describe('PerfilComponent', () => {
   it('should load client data successfully', async () => {
     const userServiceMock = {
       getUserId: jest.fn().mockReturnValue(1),
-      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
+      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente', rol: 'Cliente', documento: 1, exp: Math.floor(Date.now() / 1000) + 1000 }),
     } as Partial<UserService>;
     const clienteData = {
       direccion: 'Calle 1',
@@ -82,7 +82,7 @@ describe('PerfilComponent', () => {
   it('should handle error when service fails', async () => {
     const userServiceMock = {
       getUserId: jest.fn().mockReturnValue(1),
-      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
+      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente', rol: 'Cliente', documento: 1, exp: Math.floor(Date.now() / 1000) + 1000 }),
     } as Partial<UserService>;
     const clienteServiceMock = {
       getClienteId: jest
@@ -112,7 +112,7 @@ describe('PerfilComponent', () => {
   it('should leave observaciones empty when not frequent client', async () => {
     const userServiceMock = {
       getUserId: jest.fn().mockReturnValue(1),
-      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente' }),
+      decodeToken: jest.fn().mockReturnValue({ nombre: 'Cliente', rol: 'Cliente', documento: 1, exp: Math.floor(Date.now() / 1000) + 1000 }),
     } as Partial<UserService>;
     const clienteData = {
       direccion: 'Calle 2',
@@ -138,7 +138,7 @@ describe('PerfilComponent', () => {
   it('should use default values when response has no data and token lacks name', async () => {
     const userServiceMock = {
       getUserId: jest.fn().mockReturnValue(1),
-      decodeToken: jest.fn().mockReturnValue(undefined),
+      decodeToken: jest.fn().mockReturnValue(null),
     } as Partial<UserService>;
     const clienteServiceMock = {
       getClienteId: jest.fn().mockReturnValue(of({})),


### PR DESCRIPTION
## Summary
- remove unused Cliente and Trabajador imports
- add DecodedToken interface and typed decodeToken
- adjust related tests to expect new token shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28c9d211c83259b1d80293f8af70b