### PR TITLE
refactor(header): declarative role-based menu

### DIFF
--- a/src/app/shared/components/header/header.component.spec.ts
+++ b/src/app/shared/components/header/header.component.spec.ts
@@ -58,7 +58,11 @@ describe('HeaderComponent', () => {
     expect(component.userRole).toBe('Cliente');
     const allMenu = [...component.menuLeft, ...component.menuRight];
     expect(allMenu.some(item => item.label === 'Perfil')).toBe(true);
+    expect(allMenu.some(item => item.label === '🛒')).toBe(true);
     expect(allMenu.some(item => item.label === 'Logout')).toBe(true);
+    expect(allMenu.some(item => item.label === 'Inicio')).toBe(false);
+    expect(allMenu.some(item => item.label === 'Ubicación')).toBe(false);
+    expect(allMenu.some(item => item.label === 'Galería')).toBe(false);
   });
 
   it('should generate menu for user "Administrador"', () => {
@@ -69,10 +73,13 @@ describe('HeaderComponent', () => {
     expect(component.userRole).toBe('Administrador');
     const allMenu = [...component.menuLeft, ...component.menuRight];
     expect(allMenu.some(item => item.label === 'Registrar')).toBe(true);
+    expect(allMenu.some(item => item.label === 'Domicilios')).toBe(true);
+    expect(allMenu.some(item => item.label === 'Productos')).toBe(true);
     expect(allMenu.some(item => item.label === 'Logout')).toBe(true);
     expect(allMenu.some(item => item.label === 'Galería')).toBe(false);
     expect(allMenu.some(item => item.label === 'Menú')).toBe(false);
     expect(allMenu.some(item => item.label === 'Ubicación')).toBe(false);
+    expect(allMenu.some(item => item.label === 'Inicio')).toBe(false);
   });
 
   it('should generate menu for user "Mesero"', () => {
@@ -84,6 +91,7 @@ describe('HeaderComponent', () => {
     const allMenu = [...component.menuLeft, ...component.menuRight];
     expect(allMenu.some(item => item.label === 'Pedidos')).toBe(true);
     expect(allMenu.some(item => item.label === 'Logout')).toBe(true);
+    expect(allMenu.some(item => item.label === 'Galería')).toBe(true);
   });
 
   it('should generate menu for user "Domiciliario"', () => {
@@ -93,7 +101,11 @@ describe('HeaderComponent', () => {
 
     expect(component.userRole).toBe('Domiciliario');
     const allMenu = [...component.menuLeft, ...component.menuRight];
+    expect(allMenu.some(item => item.label === 'Domicilios')).toBe(true);
     expect(allMenu.some(item => item.label === 'Logout')).toBe(true);
+    expect(allMenu.some(item => item.label === 'Galería')).toBe(false);
+    expect(allMenu.some(item => item.label === 'Menú')).toBe(false);
+    expect(allMenu.some(item => item.label === 'Reservas')).toBe(false);
   });
 
   it('should update imagenVisible based on screen width and total menu items', () => {

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -7,6 +7,44 @@ import { UserService } from '../../../core/services/user.service';
 import { MenuItem } from '../../models/menu-item.model';
 import { CartService } from '../../../core/services/cart.service';
 
+interface RoleMenuConfig {
+  add?: MenuItem[];
+  remove?: string[];
+}
+
+const BASE_MENU: MenuItem[] = [
+  { label: 'Inicio', route: '/home', priority: 1 },
+  { label: 'Menú', route: '/menu', priority: 2 },
+  { label: 'Ubicación', route: '/ubicacion', priority: 2 },
+  { label: 'Reservas', route: '/reservas', priority: 4 },
+  { label: 'Galería', route: '/gallery', priority: 5 },
+];
+
+const ROLE_MENU_CONFIG: Record<string, RoleMenuConfig> = {
+  Cliente: {
+    add: [
+      { label: 'Perfil', route: 'cliente/perfil', priority: 7 },
+      { label: '🛒', route: 'cliente/carrito-cliente', priority: 8 },
+    ],
+    remove: ['Inicio', 'Ubicación', 'Galería'],
+  },
+  Administrador: {
+    add: [
+      { label: 'Registrar', route: 'admin/registro-admin', priority: 6 },
+      { label: 'Domicilios', route: '/domicilios/consultar', priority: 3 },
+      { label: 'Productos', route: '/admin/productos/', priority: 3 },
+    ],
+    remove: ['Inicio', 'Galería', 'Menú', 'Ubicación'],
+  },
+  Mesero: {
+    add: [{ label: 'Pedidos', route: '/pedidos', priority: 8 }],
+  },
+  Domiciliario: {
+    add: [{ label: 'Domicilios', route: '/trabajador/domicilios/tomar', priority: 8 }],
+    remove: ['Galería', 'Menú', 'Reservas'],
+  },
+};
+
 @Component({
   selector: 'app-header',
   imports: [RouterModule, CommonModule],
@@ -62,44 +100,20 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private generateMenu(): void {
-    let menuItems: MenuItem[] = [
-      { label: 'Inicio', route: '/home', priority: 1 },
-      { label: 'Menú', route: '/menu', priority: 2 },
-      { label: 'Ubicación', route: '/ubicacion', priority: 2 },
-      { label: 'Reservas', route: '/reservas', priority: 4 },
-      { label: 'Galería', route: '/gallery', priority: 5 },
-    ];
+    const items = new Map<string, MenuItem>();
+
+    BASE_MENU.forEach(item => items.set(item.label, item));
 
     if (!this.userRole) {
-      menuItems.push({ label: 'Login', route: '/login', priority: 99 });
+      items.set('Login', { label: 'Login', route: '/login', priority: 99 });
     } else {
-      menuItems.push({ label: 'Logout', route: '/logout', priority: 99 });
-
-      if (this.userRole === 'Cliente') {
-        menuItems.unshift({ label: 'Perfil', route: 'cliente/perfil', priority: 7 });
-        menuItems.unshift({ label: '🛒', route: 'cliente/carrito-cliente', priority: 8 });
-        menuItems = menuItems.filter(item => item.label !== 'Inicio');
-        menuItems = menuItems.filter(item => item.label !== 'Ubicación');
-        menuItems = menuItems.filter(item => item.label !== 'Galería');
-      } else if (this.userRole === 'Administrador') {
-        menuItems.unshift({ label: 'Registrar', route: 'admin/registro-admin', priority: 6 });
-        menuItems = menuItems.filter(item => item.label !== 'Inicio');
-        menuItems = menuItems.filter(item => item.label !== 'Galería');
-        menuItems = menuItems.filter(item => item.label !== 'Menú');
-        menuItems = menuItems.filter(item => item.label !== 'Ubicación');
-        menuItems.unshift({ label: 'Domicilios', route: '/domicilios/consultar', priority: 3 });
-        menuItems.unshift({ label: 'Productos', route: '/admin/productos/', priority: 3 });
-      } else if (this.userRole === 'Mesero') {
-        menuItems.push({ label: 'Pedidos', route: '/pedidos', priority: 8 });
-      } else if (this.userRole === 'Domiciliario') {
-        menuItems.push({ label: 'Domicilios', route: '/trabajador/domicilios/tomar', priority: 8 });
-        menuItems = menuItems.filter(item => item.label !== 'Galería');
-        menuItems = menuItems.filter(item => item.label !== 'Menú');
-        menuItems = menuItems.filter(item => item.label !== 'Reservas');
-      }
+      items.set('Logout', { label: 'Logout', route: '/logout', priority: 99 });
+      const config = ROLE_MENU_CONFIG[this.userRole];
+      config?.add?.forEach(item => items.set(item.label, item));
+      config?.remove?.forEach(label => items.delete(label));
     }
 
-    menuItems.sort((a, b) => a.priority - b.priority);
+    const menuItems = Array.from(items.values()).sort((a, b) => a.priority - b.priority);
 
     const midIndex = Math.ceil(menuItems.length / 2);
     this.menuLeft = menuItems.slice(0, midIndex);


### PR DESCRIPTION
## Summary
- replace repeated filters in header menu generation with map-based approach
- centralize menu additions and removals per role via configuration object
- expand header tests to cover role-specific menu expectations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28cf6975083259ac293868fc64a4f