### PR TITLE
feat: improve JWT handling with typed payload

### DIFF
--- a/src/app/shared/models/jwt-payload.model.ts
+++ b/src/app/shared/models/jwt-payload.model.ts
@@ -1,0 +1,6 @@
+export interface JwtPayload {
+    rol: string;
+    exp: number;
+    documento: number;
+    nombre?: string;
+}


### PR DESCRIPTION
## Summary
- add JwtPayload interface
- validate token format and decode into typed payload
- cover valid, expired and malformed tokens in user service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28d054ea0832591c0ece4a0398587