### PR TITLE
refactor: add log levels and environment-aware logging

### DIFF
--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -1,19 +1,34 @@
 import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+
+export enum LogLevel {
+  INFO = 'info',
+  WARN = 'warn',
+  ERROR = 'error'
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class LoggingService {
-  log(message: any, ...optionalParams: any[]): void {
-    console.info(message, ...optionalParams);
-  }
+  private readonly isProduction = environment.production;
 
-  error(message: any, ...optionalParams: any[]): void {
-    console.error(message, ...optionalParams);
-  }
+  log<T>(level: LogLevel, message: T, ...optionalParams: unknown[]): void {
+    if (this.isProduction && level !== LogLevel.ERROR) {
+      return;
+    }
 
-  warn(message: any, ...optionalParams: any[]): void {
-    console.warn(message, ...optionalParams);
+    switch (level) {
+      case LogLevel.INFO:
+        console.info(message, ...optionalParams);
+        break;
+      case LogLevel.WARN:
+        console.warn(message, ...optionalParams);
+        break;
+      case LogLevel.ERROR:
+        console.error(message, ...optionalParams);
+        break;
+    }
   }
 }
 

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { LoggingService } from './logging.service';
+import { LoggingService, LogLevel } from './logging.service';
 
 @Injectable({
   providedIn: 'root',
@@ -14,7 +14,7 @@ export class ModalService {
   constructor(private logger: LoggingService) {}
 
   openModal(data: any) {
-    this.logger.log('Entra');
+    this.logger.log(LogLevel.INFO, 'Entra');
     this.modalData.next(data);
     this.isOpen.next(true);
   }
@@ -24,7 +24,7 @@ export class ModalService {
   }
 
   getModalData(): any {
-    this.logger.log('getModalData');
+    this.logger.log(LogLevel.INFO, 'getModalData');
     return this.modalData.value;
   }
 }

--- a/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts
+++ b/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.spec.ts
@@ -44,8 +44,7 @@ describe('ConsultarReservaComponent', () => {
     } as unknown as jest.Mocked<UserService>;
 
     const loggingServiceMock = {
-      log: jest.fn(),
-      error: jest.fn()
+      log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
     await TestBed.configureTestingModule({

--- a/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.ts
+++ b/src/app/modules/public/reservas/consultar-reserva/consultar-reserva.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
-import { LoggingService } from '../../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../../core/services/logging.service';
 
 import { ReservaService } from '../../../../core/services/reserva.service';
 import { UserService } from '../../../../core/services/user.service';
@@ -151,7 +151,7 @@ export class ConsultarReservaComponent implements OnInit {
         this.toastr.success(`Reserva marcada como ${nuevoEstado}`, 'Actualización Exitosa');
       },
       error: (error) => {
-        this.logger.error('Error:', error);
+        this.logger.log(LogLevel.ERROR, 'Error:', error);
         this.toastr.error('Ocurrió un error al actualizar la reserva', 'Error');
       }
     });

--- a/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.spec.ts
+++ b/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.spec.ts
@@ -16,7 +16,7 @@ import { Trabajador } from '../../../../shared/models/trabajador.model';
 import { mockTrabajadorResponse } from '../../../../shared/mocks/trabajador.mock';
 import { mockResponseCliente } from '../../../../shared/mocks/cliente.mock';
 import { ClienteService } from '../../../../core/services/cliente.service';
-import { LoggingService } from '../../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../../core/services/logging.service';
 
 describe('CrearReservaComponent', () => {
   let component: CrearReservaComponent;
@@ -61,8 +61,7 @@ describe('CrearReservaComponent', () => {
     } as unknown as jest.Mocked<Router>;
 
     const loggingServiceMock = {
-      log: jest.fn(),
-      error: jest.fn()
+      log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
     await TestBed.configureTestingModule({
@@ -287,7 +286,7 @@ describe('CrearReservaComponent', () => {
     component.onSubmit();
 
     expect(trabajadorService.getTrabajadorId).toHaveBeenCalledWith(1);
-    expect(loggingService.error).toHaveBeenCalledWith('Error al crear la reserva', errorResponse);
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error al crear la reserva', errorResponse);
     expect(toastr.error).toHaveBeenCalledWith("Error creando reserva", 'Error');
     expect(router.navigate).not.toHaveBeenCalled();
   });

--- a/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.ts
+++ b/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.ts
@@ -9,7 +9,7 @@ import { UserService } from '../../../../core/services/user.service';
 import { estadoReserva } from '../../../../shared/constants';
 import { Reserva } from '../../../../shared/models/reserva.model';
 import { TrabajadorService } from '../../../../core/services/trabajador.service';
-import { LoggingService } from '../../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../../core/services/logging.service';
 
 @Component({
   selector: 'app-reserva',
@@ -136,7 +136,7 @@ export class CrearReservaComponent implements OnInit {
         this.router.navigate(['/reservas']);
       },
       error: (error) => {
-        this.logger.error('Error al crear la reserva', error);
+        this.logger.log(LogLevel.ERROR, 'Error al crear la reserva', error);
         this.toastr.error(error.message, 'Error');
       }
     });

--- a/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.spec.ts
+++ b/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.spec.ts
@@ -6,7 +6,7 @@ import { CommonModule } from '@angular/common';
 import { of, throwError } from 'rxjs';
 import { Reserva } from '../../../../shared/models/reserva.model';
 import { mockReservaResponse, mockReservasDelDiaResponse } from '../../../../shared/mocks/reserva.mocks';
-import { LoggingService } from '../../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../../core/services/logging.service';
 
 describe('ReservasDelDiaComponent', () => {
   let component: ReservasDelDiaComponent;
@@ -27,8 +27,7 @@ describe('ReservasDelDiaComponent', () => {
     } as unknown as jest.Mocked<ToastrService>;
 
     const loggingServiceMock = {
-      log: jest.fn(),
-      error: jest.fn()
+      log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
     await TestBed.configureTestingModule({
@@ -130,7 +129,7 @@ describe('ReservasDelDiaComponent', () => {
       reservaService.actualizarReserva.mockReturnValue(throwError(() => errorResponse));
       component['actualizarReserva'](reserva);
 
-      expect(loggingService.error).toHaveBeenCalledWith('Error:', errorResponse);
+      expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error:', errorResponse);
       expect(toastr.error).toHaveBeenCalledWith('Ocurrió un error al actualizar la reserva', 'Error');
     });
   });

--- a/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.ts
+++ b/src/app/modules/public/reservas/reservas-del-dia/reservas-del-dia.component.ts
@@ -4,7 +4,7 @@ import { ReservaService } from '../../../../core/services/reserva.service';
 import { Reserva } from '../../../../shared/models/reserva.model';
 import { ToastrService } from 'ngx-toastr';
 import { estadoReserva } from '../../../../shared/constants';
-import { LoggingService } from '../../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../../core/services/logging.service';
 
 @Component({
   selector: 'app-reservas-del-dia',
@@ -72,7 +72,7 @@ export class ReservasDelDiaComponent implements OnInit {
         this.toastr.success(`Reserva marcada como ${reserva.estadoReserva}`, 'Actualización Exitosa');
       },
       error: (error) => {
-        this.logger.error('Error:', error);
+        this.logger.log(LogLevel.ERROR, 'Error:', error);
         this.toastr.error('Ocurrió un error al actualizar la reserva', 'Error');
       }
     });

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
@@ -61,8 +61,7 @@ describe('RutaDomicilioComponent', () => {
     };
 
     const loggingServiceMock = {
-      log: jest.fn(),
-      error: jest.fn()
+      log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
     const routerMock = {

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -8,7 +8,7 @@ import { estadoPago } from '../../../../shared/constants';
 import { ModalService } from '../../../../core/services/modal.service';
 import { ToastrService } from 'ngx-toastr';
 import { SafePipe } from "../../../../shared/pipes/safe.pipe";
-import { LoggingService } from '../../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../../core/services/logging.service';
 
 @Component({
   selector: 'app-ruta-domicilio',
@@ -71,7 +71,7 @@ export class RutaDomicilioComponent implements OnInit {
         .subscribe(
           response => {
             this.toastrService.success('Domicilio marcado como finalizado');
-            this.logger.log('Domicilio marcado como finalizado', response);
+            this.logger.log(LogLevel.INFO, 'Domicilio marcado como finalizado', response);
           },
           error => {
             console.error('Error al marcar finalizado', error);
@@ -103,7 +103,7 @@ export class RutaDomicilioComponent implements OnInit {
               const modalData = this.modalService.getModalData();
               if (modalData.select?.selected) {
                 const metodoPagoSeleccionado = modalData.select.selected;
-                this.logger.log('Método de pago seleccionado:', metodoPagoSeleccionado);
+                this.logger.log(LogLevel.INFO, 'Método de pago seleccionado:', metodoPagoSeleccionado);
                 this.domicilioService.updateDomicilio(this.domicilioId, {
                   estadoPago: estadoPago.PAGADO
                 }).subscribe(

--- a/src/app/shared/components/footer/footer.component.spec.ts
+++ b/src/app/shared/components/footer/footer.component.spec.ts
@@ -4,7 +4,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { RestauranteService } from '../../../core/services/restaurante.service';
 import { of, throwError } from 'rxjs';
 import { mockCambioHorarioResponse, mockCambioHorarioAbiertoResponse, mockRestauranteResponse } from '../../mocks/restaurante.mock';
-import { LoggingService } from '../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../core/services/logging.service';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -29,8 +29,7 @@ describe('FooterComponent', () => {
     };
 
     const loggingServiceMock = {
-      log: jest.fn(),
-      error: jest.fn()
+      log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
     await TestBed.configureTestingModule({
@@ -89,7 +88,7 @@ describe('FooterComponent', () => {
     restauranteService.getCambiosHorario.mockReturnValue(throwError(() => mockError));
     fixture.detectChanges();
 
-    expect(loggingService.error).toHaveBeenCalledWith(mockError);
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, mockError);
   });
   it('should set estadoActual to "Cerrado" when current time is outside of opening hours', () => {
     restauranteService.getRestauranteInfo.mockReturnValue(of(mockRestauranteResponse));

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -3,7 +3,7 @@ import { Restaurante } from '../../models/restaurante.model';
 import { CambioHorario } from '../../models/cambio-horario.model';
 import { ApiResponse } from '../../models/api-response.model';
 import { RestauranteService } from '../../../core/services/restaurante.service';
-import { LoggingService } from '../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../core/services/logging.service';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 
@@ -47,7 +47,7 @@ export class FooterComponent {
         }
         this.cambioHorario = response;
       },
-      error: (error) => { this.logger.error(error); },
+      error: (error) => { this.logger.log(LogLevel.ERROR, error); },
     });
   }
 


### PR DESCRIPTION
## Summary
- replace generic any-based logger with LogLevel enum and environment-aware logging
- use the new log method across services and components
- adjust tests for updated logging API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28d0ee56c8325a22c6a867d5a3f87