### PR TITLE
refactor: streamline services and update worker response typing

### DIFF
--- a/src/app/core/services/cliente.service.ts
+++ b/src/app/core/services/cliente.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable, catchError, map } from 'rxjs';
+import { Observable, catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Cliente } from '../../shared/models/cliente.model';
@@ -11,7 +11,6 @@ import { HandleErrorService } from './handle-error.service';
 })
 export class ClienteService {
   private baseUrl = environment.apiUrl;
-  private tokenKey = 'auth_token';
 
   constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 

--- a/src/app/core/services/trabajador.service.ts
+++ b/src/app/core/services/trabajador.service.ts
@@ -11,7 +11,6 @@ import { Trabajador } from '../../shared/models/trabajador.model';
 })
 export class TrabajadorService {
   private baseUrl = environment.apiUrl;
-  private tokenKey = 'auth_token';
   constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 
   registroTrabajador(trabajador: Trabajador): Observable<ApiResponse<Trabajador>> {
@@ -22,12 +21,12 @@ export class TrabajadorService {
   searchTrabajador(documento_trabajador: number): Observable<ApiResponse<Trabajador>> {
     return this.http.get<ApiResponse<Trabajador>>(`${this.baseUrl}/trabajadores/search?id=${documento_trabajador}`).pipe(
       catchError(this.handleError.handleError)
-    )
+    );
   }
 
   getTrabajadores(): Observable<Trabajador[]> {
     return this.http.get<ApiResponse<Trabajador[]>>(`${this.baseUrl}/trabajadores`).pipe(
-      map((response: { data: any; }) => response.data),
+      map((res: ApiResponse<Trabajador[]>) => res.data),
       catchError(this.handleError.handleError)
     );
   }


### PR DESCRIPTION
## Summary
- remove unused token handling from ClienteService and TrabajadorService
- type trabajador list mapping as ApiResponse<Trabajador[]>
- ensure trabajador search method uses error handler consistently

## Testing
- `npm test` *(fails: LoginComponent should handle login error and show toastr error message from service)*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a10009c48325ab26760f99eac47e