### PR TITLE
Refactor modal typing and remove anys

### DIFF
--- a/src/app/core/services/domicilio.service.ts
+++ b/src/app/core/services/domicilio.service.ts
@@ -19,7 +19,7 @@ export class DomicilioService {
    * @param params 
    * @returns 
    */
-  getDomicilios(params?: any): Observable<ApiResponse<Domicilio[]>> {
+  getDomicilios(params?: Record<string, unknown>): Observable<ApiResponse<Domicilio[]>> {
     return this.http.get<ApiResponse<Domicilio[]>>(this.baseUrl, { params }).pipe(
       catchError(this.handleError.handleError)
     );
@@ -60,8 +60,8 @@ export class DomicilioService {
    * Elimina un domicilio por ID.
    * @param id ID del domicilio
    */
-  deleteDomicilio(id: number): Observable<ApiResponse<any>> {
-    return this.http.delete<ApiResponse<any>>(`${this.baseUrl}?id=${id}`).pipe(
+  deleteDomicilio(id: number): Observable<ApiResponse<unknown>> {
+    return this.http.delete<ApiResponse<unknown>>(`${this.baseUrl}?id=${id}`).pipe(
       catchError(this.handleError.handleError)
     );
   }

--- a/src/app/core/services/modal.service.spec.ts
+++ b/src/app/core/services/modal.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { ModalService } from './modal.service';
 import { LoggingService } from './logging.service';
+import { ModalData } from '../../shared/models/modal-data.model';
 
 describe('ModalService', () => {
   let service: ModalService;
@@ -27,7 +28,7 @@ describe('ModalService', () => {
   });
 
   it('should update modalData and set isOpen to true when openModal is called', () => {
-    const data = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const data: ModalData = { title: 'Test Modal', buttons: [] };
     service.openModal(data);
 
     expect(service.getModalData()).toEqual(data);
@@ -40,7 +41,7 @@ describe('ModalService', () => {
   });
 
   it('should set isOpen to false when closeModal is called', () => {
-    service.openModal({ title: 'Test Modal' });
+    service.openModal({ title: 'Test Modal', buttons: [] });
     service.closeModal();
 
     let isOpenValue: boolean | undefined;

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -1,19 +1,20 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { ModalData } from '../../shared/models/modal-data.model';
 import { LoggingService, LogLevel } from './logging.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ModalService {
-  private modalData = new BehaviorSubject<any>(null);
+  private modalData = new BehaviorSubject<ModalData | null>(null);
   modalData$ = this.modalData.asObservable();
   private isOpen = new BehaviorSubject<boolean>(false);
   isOpen$ = this.isOpen.asObservable();
 
   constructor(private logger: LoggingService) {}
 
-  openModal(data: any) {
+  openModal(data: ModalData) {
     this.logger.log(LogLevel.INFO, 'Entra');
     this.modalData.next(data);
     this.isOpen.next(true);
@@ -23,7 +24,7 @@ export class ModalService {
     this.isOpen.next(false);
   }
 
-  getModalData(): any {
+  getModalData(): ModalData | null {
     this.logger.log(LogLevel.INFO, 'getModalData');
     return this.modalData.value;
   }

--- a/src/app/core/services/producto.service.ts
+++ b/src/app/core/services/producto.service.ts
@@ -19,7 +19,7 @@ export class ProductoService {
    * @param params 
    * @returns 
    */
-  getProductos(params?: any): Observable<ApiResponse<Producto[]>> {
+  getProductos(params?: Record<string, unknown>): Observable<ApiResponse<Producto[]>> {
     return this.http.get<ApiResponse<Producto[]>>(`${this.baseUrl}`, { params }).pipe(
       catchError(this.handleError.handleError)
     );

--- a/src/app/core/services/trabajador.service.ts
+++ b/src/app/core/services/trabajador.service.ts
@@ -27,7 +27,7 @@ export class TrabajadorService {
 
   getTrabajadores(): Observable<Trabajador[]> {
     return this.http.get<ApiResponse<Trabajador[]>>(`${this.baseUrl}/trabajadores`).pipe(
-      map((response: { data: any; }) => response.data),
+      map((response: ApiResponse<Trabajador[]>) => response.data),
       catchError(this.handleError.handleError)
     );
   }

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -10,7 +10,7 @@ export interface DecodedToken {
   rol: string;
   documento: number;
   exp: number;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 @Injectable({

--- a/src/app/modules/auth/login/login.component.spec.ts
+++ b/src/app/modules/auth/login/login.component.spec.ts
@@ -8,7 +8,7 @@ import { of, throwError } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { mockLogin } from '../../../shared/mocks/login.mock';
-import { LoggingService } from '../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../core/services/logging.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -100,7 +100,7 @@ describe('LoginComponent', () => {
     component.onSubmit();
 
     expect(toastr.error).toHaveBeenCalledWith('Error de conexión', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('err.message:', 'Error de conexión');
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error de inicio de sesión', mockError);
   });
 
   it('should handle login error and show generic toastr error message when message is missing', () => {
@@ -110,6 +110,6 @@ describe('LoginComponent', () => {
     component.onSubmit();
 
     expect(toastr.error).toHaveBeenCalledWith('Credenciales incorrectas', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('No hay propiedad "message" en el error.');
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'No hay propiedad "message" en el error.');
   });
 });

--- a/src/app/modules/auth/register/register.component.ts
+++ b/src/app/modules/auth/register/register.component.ts
@@ -21,7 +21,7 @@ import { TrabajadorService } from '../../../core/services/trabajador.service';
 })
 export class RegisterComponent implements OnInit {
 
-  documento: any;
+  documento: number | null = null;
   nombre: string = '';
   apellido: string = '';
   direccion: string = '';

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -20,6 +20,7 @@ import { Producto } from '../../../shared/models/producto.model';
 import { MetodosPago } from '../../../shared/models/metodo-pago.model';
 import { Domicilio } from '../../../shared/models/domicilio.model';
 import { Cliente } from '../../../shared/models/cliente.model';
+import { ApiResponse } from '../../../shared/models/api-response.model';
 import { estadoPago } from '../../../shared/constants';
 
 @Component({
@@ -103,8 +104,9 @@ export class CarritoComponent implements OnInit, OnDestroy {
   }
 
   private onCheckoutConfirm() {
-    const { selects } = this.modalService.getModalData();
-    const [methodSelect, deliverySelect] = selects;
+    const data = this.modalService.getModalData();
+    if (!data?.selects) { return; }
+    const [methodSelect, deliverySelect] = data.selects;
     const methodId      = methodSelect.selected as number;
     const needsDelivery = deliverySelect.selected as boolean;
 
@@ -124,9 +126,9 @@ export class CarritoComponent implements OnInit, OnDestroy {
       catchError(err => {
         console.error('Error al obtener datos del cliente:', err);
         // En caso de error, retornamos null para interrumpir el flujo
-        return of(null as any);
+        return of<ApiResponse<Cliente> | null>(null);
       }),
-      switchMap((resCliente) => {
+      switchMap((resCliente: ApiResponse<Cliente> | null) => {
         if (!resCliente || !resCliente.data) {
           throw new Error('No se pudo obtener la información del cliente');
         }

--- a/src/app/modules/client/mis-pedidos/mis-pedidos.component.ts
+++ b/src/app/modules/client/mis-pedidos/mis-pedidos.component.ts
@@ -19,6 +19,8 @@ type DetallesAPI = {
   PRODUCTOS?: string; // viene como string JSON
 };
 
+type ProductoDetalle = Record<string, unknown>;
+
 type PedidoCard = Pedido & {
   total?: number;
   items?: number;
@@ -26,7 +28,7 @@ type PedidoCard = Pedido & {
   metodoPago?: string;
   direccion?: string;
   telefono?: string;
-  productos?: any[];
+  productos?: ProductoDetalle[];
 };
 
 @Component({
@@ -94,7 +96,7 @@ export class MisPedidosComponent implements OnInit, OnDestroy {
     if (!det) return { ...p };
 
     // Parse de PRODUCTOS (viene como string JSON)
-    let productos: any[] | undefined;
+    let productos: ProductoDetalle[] | undefined;
     try {
       const parsed = det.PRODUCTOS ? JSON.parse(det.PRODUCTOS) : [];
       productos = Array.isArray(parsed) ? parsed : [];

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
@@ -6,6 +6,7 @@ import { TrabajadorService } from '../../../../core/services/trabajador.service'
 import { ModalService } from '../../../../core/services/modal.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { Trabajador } from '../../../../shared/models/trabajador.model';
 
 @Component({
   selector: 'app-consultar-domicilio',
@@ -15,7 +16,7 @@ import { FormsModule } from '@angular/forms';
 })
 export class ConsultarDomicilioComponent implements OnInit {
   domicilios: Domicilio[] = [];
-  trabajadores: any[] = [];
+  trabajadores: Trabajador[] = [];
   buscarPorDireccion: boolean = false;
   buscarPorTelefono: boolean = false;
   buscarPorFecha: boolean = false;
@@ -43,7 +44,7 @@ export class ConsultarDomicilioComponent implements OnInit {
   }
 
   buscarDomicilios(): void {
-    const params: any = {};
+    const params: Record<string, string> = {};
 
     if (this.buscarPorDireccion && this.direccion) params.direccion = this.direccion;
     if (this.buscarPorTelefono && this.telefono) params.telefono = this.telefono;
@@ -88,7 +89,7 @@ export class ConsultarDomicilioComponent implements OnInit {
             class: 'btn btn-success',
             action: () => {
               const modalData = this.modalService.getModalData();
-              if (modalData.select?.selected) {
+              if (modalData?.select?.selected) {
                 this.confirmarAsignacion(domicilio, modalData.select.selected);
                 this.modalService.closeModal();
               }

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -101,7 +101,7 @@ export class RutaDomicilioComponent implements OnInit {
             class: 'btn btn-success',
             action: () => {
               const modalData = this.modalService.getModalData();
-              if (modalData.select?.selected) {
+              if (modalData?.select?.selected) {
                 const metodoPagoSeleccionado = modalData.select.selected;
                 this.logger.log(LogLevel.INFO, 'Método de pago seleccionado:', metodoPagoSeleccionado);
                 this.domicilioService.updateDomicilio(this.domicilioId, {

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -23,7 +23,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   cartCount = 0;
   private destroy$ = new Subject<void>();
 
-  constructor(private userService: UserService, @Inject(PLATFORM_ID) private platformId: any, private router: Router, private cartService: CartService) {
+  constructor(private userService: UserService, @Inject(PLATFORM_ID) private platformId: object, private router: Router, private cartService: CartService) {
     this.isBrowser = isPlatformBrowser(this.platformId);
   }
 

--- a/src/app/shared/components/modal/modal.component.html
+++ b/src/app/shared/components/modal/modal.component.html
@@ -1,16 +1,16 @@
 <div class="modal-overlay" *ngIf="isOpen" (click)="close()">
     <div class="modal-content" (click)="$event.stopPropagation()">
         <div class="modal-header">
-            <h2 *ngIf="modalData.title">{{ modalData.title }}</h2>
+            <h2 *ngIf="modalData?.title">{{ modalData?.title }}</h2>
             <button class="close-btn" (click)="close()">&times;</button>
         </div>
 
         <div class="modal-body">
-            <img *ngIf="modalData.image" [src]="modalData.image" alt="Imagen modal" />
+            <img *ngIf="modalData?.image" [src]="modalData?.image" alt="Imagen modal" />
 
-            <div class="mt-3" *ngIf="modalData.message" [innerHTML]="modalData.message"></div>
+            <div class="mt-3" *ngIf="modalData?.message" [innerHTML]="modalData?.message"></div>
 
-            <ng-container *ngIf="modalData.selects">
+            <ng-container *ngIf="modalData?.selects">
                 <div *ngFor="let sel of modalData.selects" class="form-group mt-3">
                     <label>{{ sel.label }}</label>
                     <select class="form-control" [(ngModel)]="sel.selected">
@@ -21,7 +21,7 @@
                 </div>
             </ng-container>
 
-            <div *ngIf="modalData.select">
+            <div *ngIf="modalData?.select">
                 <label>{{ modalData.select.label }}</label>
                 <select class="form-control" [(ngModel)]="modalData.select.selected">
                     <option *ngFor="let item of modalData.select.options" [value]="item.value">
@@ -31,7 +31,7 @@
             </div>
         </div>
 
-        <div class="modal-buttons" *ngIf="modalData.buttons">
+        <div class="modal-buttons" *ngIf="modalData?.buttons">
             <button *ngFor="let btn of modalData.buttons" (click)="btn.action()" [class]="btn.class">
                 {{ btn.label }}
             </button>

--- a/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/app/shared/components/modal/modal.component.spec.ts
@@ -1,18 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalComponent } from './modal.component';
 import { ModalService } from '../../../core/services/modal.service';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { ModalData } from '../../models/modal-data.model';
 
 describe('ModalComponent', () => {
   let component: ModalComponent;
   let fixture: ComponentFixture<ModalComponent>;
-  let modalServiceSpy: any;
-  let modalDataSubject: BehaviorSubject<any>;
+  let modalServiceSpy: { modalData$: Observable<ModalData | null>; isOpen$: Observable<boolean>; closeModal: jest.Mock };
+  let modalDataSubject: BehaviorSubject<ModalData | null>;
   let isOpenSubject: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
-    modalDataSubject = new BehaviorSubject(null);
-    isOpenSubject = new BehaviorSubject(false);
+    modalDataSubject = new BehaviorSubject<ModalData | null>(null);
+    isOpenSubject = new BehaviorSubject<boolean>(false);
     modalServiceSpy = {
       modalData$: modalDataSubject.asObservable(),
       isOpen$: isOpenSubject.asObservable(),
@@ -36,7 +37,7 @@ describe('ModalComponent', () => {
   });
 
   it('should update modalData when modalService emits new data', () => {
-    const testData = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const testData: ModalData = { title: 'Test Modal', buttons: [] };
     modalDataSubject.next(testData);
     fixture.detectChanges();
     expect(component.modalData).toEqual(testData);

--- a/src/app/shared/components/modal/modal.component.ts
+++ b/src/app/shared/components/modal/modal.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ModalService } from '../../../core/services/modal.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ModalData } from '../../models/modal-data.model';
 
 @Component({
   selector: 'app-modal',
@@ -12,15 +13,13 @@ import { FormsModule } from '@angular/forms';
 })
 export class ModalComponent implements OnInit {
   isOpen = false;
-  modalData: any = {};
+  modalData: ModalData | null = null;
 
   constructor(private modalService: ModalService) { }
 
   ngOnInit() {
     this.modalService.modalData$.subscribe((data) => {
-      if (data) {
-        this.modalData = data;
-      }
+      this.modalData = data;
     });
 
     this.modalService.isOpen$.subscribe((state) => {

--- a/src/app/shared/mocks/fakeDomSanitizer.ts
+++ b/src/app/shared/mocks/fakeDomSanitizer.ts
@@ -6,7 +6,7 @@ export class FakeDomSanitizer extends DomSanitizer {
     bypassSecurityTrustResourceUrl(url: string): SafeResourceUrl {
         return { toString: () => url, changingThisBreaksApplicationSecurity: url } as unknown as SafeResourceUrl;
     }
-    sanitize(context: any, value: SafeResourceUrl | string | null): string | null {
+    sanitize(context: unknown, value: SafeResourceUrl | string | null): string | null {
         if (!value) { return null; }
         return value.toString();
     }

--- a/src/app/shared/models/modal-data.model.ts
+++ b/src/app/shared/models/modal-data.model.ts
@@ -1,0 +1,25 @@
+export interface ModalButton {
+    label: string;
+    class: string;
+    action: () => void;
+}
+
+export interface ModalOption<T = unknown> {
+    label: string;
+    value: T;
+}
+
+export interface ModalSelect<T = unknown> {
+    label: string;
+    options: ModalOption<T>[];
+    selected: T | null;
+}
+
+export interface ModalData {
+    title: string;
+    message?: string;
+    image?: string;
+    select?: ModalSelect;
+    selects?: ModalSelect[];
+    buttons: ModalButton[];
+}

--- a/src/app/shared/pipes/safe.pipe.ts
+++ b/src/app/shared/pipes/safe.pipe.ts
@@ -16,7 +16,7 @@ export class SafePipe implements PipeTransform {
   constructor(protected sanitizer: DomSanitizer) { }
 
   public transform(
-    value: any,
+    value: unknown,
     type: string
   ): SafeHtml | SafeStyle | SafeScript | SafeUrl | SafeResourceUrl {
     switch (type) {


### PR DESCRIPTION
## Summary
- add `ModalData` interface and use it throughout modal service and component
- replace `any` with specific or generic types in services and components
- adjust login tests to match logging implementation

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a0ddc05483258f05b63861255a87