### PR TITLE
feat(auth): add jwt decoding utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "depcheck": "^1.4.7",
     "express": "^5.1.0",
     "lightbox2": "^2.11.5",
+    "jwt-decode": "^4.0.0",
     "ngx-toastr": "^19.0.0",
     "owl.carousel": "^2.3.4",
     "rxjs": "~7.8.2",

--- a/src/app/core/services/user.service.spec.ts
+++ b/src/app/core/services/user.service.spec.ts
@@ -104,7 +104,7 @@ describe('UserService', () => {
     const encodedPayload = btoa(JSON.stringify(tokenPayload));
     localStorage.setItem('auth_token', `header.${encodedPayload}.signature`);
     const decoded = service.decodeToken();
-    expect(decoded).toEqual({ rol: 'Administrador', documento: expect.any(Number), exp: expect.any(Number) });
+    expect(decoded).toEqual(tokenPayload);
   });
 
   it('should log an error and return null if token decoding fails', () => {
@@ -148,6 +148,13 @@ describe('UserService', () => {
     const encodedPayload = btoa(JSON.stringify(validTokenPayload));
     localStorage.setItem('auth_token', `header.${encodedPayload}.signature`);
     expect(service.isTokenExpired()).toBe(false);
+  });
+
+  it('should treat malformed token as expired', () => {
+    localStorage.setItem('auth_token', 'invalid.token.value');
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(service.isTokenExpired()).toBe(true);
+    consoleSpy.mockRestore();
   });
 
   it('should return true if decodeToken returns null for token expiry', () => {

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -5,6 +5,7 @@ import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Login, LoginResponse } from '../../shared/models/login.model';
 import { HandleErrorService } from './handle-error.service';
+import jwtDecode from 'jwt-decode';
 
 export interface DecodedToken {
   rol: string;
@@ -50,17 +51,18 @@ export class UserService {
     return localStorage.getItem(this.tokenKey);
   }
 
-  decodeToken(): DecodedToken | null {
-    const token = this.getToken();
-    if (!token) return null;
-
+  private decodeTokenSafely(token: string): DecodedToken | null {
     try {
-      const payload = atob(token.split('.')[1]);
-      return JSON.parse(payload) as DecodedToken;
+      return jwtDecode<DecodedToken>(token);
     } catch (error) {
       console.error('Error al decodificar el token:', error);
       return null;
     }
+  }
+
+  decodeToken(): DecodedToken | null {
+    const token = this.getToken();
+    return token ? this.decodeTokenSafely(token) : null;
   }
 
   getUserRole(): string | null {
@@ -74,10 +76,11 @@ export class UserService {
   }
 
   isTokenExpired(): boolean {
-    const decoded: DecodedToken | null = this.decodeToken();
-    if (!decoded || !decoded.exp) return true;
+    const token = this.getToken();
+    const decoded: DecodedToken | null = token ? this.decodeTokenSafely(token) : null;
+    if (!decoded || typeof decoded.exp !== 'number') return true;
 
-    const currentTime = Math.floor(new Date().getTime() / 1000);
+    const currentTime = Math.floor(Date.now() / 1000);
     return decoded.exp < currentTime;
   }
 


### PR DESCRIPTION
## Summary
- add jwt-decode dependency
- use jwtDecode to safely parse token payloads and expiration
- cover malformed and expired tokens with unit tests

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*


------
https://chatgpt.com/codex/tasks/task_e_68a3a119ce40832585a3f65e5b5c11d1