### PR TITLE
refactor: add typed modal data

### DIFF
--- a/src/app/core/services/modal.service.spec.ts
+++ b/src/app/core/services/modal.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { ModalService } from './modal.service';
+import { ModalService, ModalData } from './modal.service';
 import { LoggingService } from './logging.service';
 
 describe('ModalService', () => {
@@ -27,7 +27,7 @@ describe('ModalService', () => {
   });
 
   it('should update modalData and set isOpen to true when openModal is called', () => {
-    const data = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const data: ModalData = { title: 'Test Modal', message: 'Contenido de prueba' };
     service.openModal(data);
 
     expect(service.getModalData()).toEqual(data);

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -2,19 +2,28 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { LoggingService, LogLevel } from './logging.service';
 
+export interface ModalData {
+  title?: string;
+  message?: string;
+  image?: string;
+  buttons?: any[];
+  select?: any;
+  selects?: any;
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class ModalService {
-  private modalData = new BehaviorSubject<any>(null);
+  private modalData = new BehaviorSubject<ModalData | null>(null);
   modalData$ = this.modalData.asObservable();
   private isOpen = new BehaviorSubject<boolean>(false);
   isOpen$ = this.isOpen.asObservable();
 
   constructor(private logger: LoggingService) {}
 
-  openModal(data: any) {
-    this.logger.log(LogLevel.INFO, 'Entra');
+  openModal(data: ModalData) {
+    this.logger.log(LogLevel.INFO, 'Opening modal');
     this.modalData.next(data);
     this.isOpen.next(true);
   }
@@ -23,7 +32,7 @@ export class ModalService {
     this.isOpen.next(false);
   }
 
-  getModalData(): any {
+  getModalData(): ModalData | null {
     this.logger.log(LogLevel.INFO, 'getModalData');
     return this.modalData.value;
   }

--- a/src/app/modules/auth/login/login.component.spec.ts
+++ b/src/app/modules/auth/login/login.component.spec.ts
@@ -8,7 +8,7 @@ import { of, throwError } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { mockLogin } from '../../../shared/mocks/login.mock';
-import { LoggingService } from '../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../core/services/logging.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -100,7 +100,7 @@ describe('LoginComponent', () => {
     component.onSubmit();
 
     expect(toastr.error).toHaveBeenCalledWith('Error de conexión', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('err.message:', 'Error de conexión');
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error de inicio de sesión', mockError);
   });
 
   it('should handle login error and show generic toastr error message when message is missing', () => {
@@ -110,6 +110,6 @@ describe('LoginComponent', () => {
     component.onSubmit();
 
     expect(toastr.error).toHaveBeenCalledWith('Credenciales incorrectas', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('No hay propiedad "message" en el error.');
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'No hay propiedad "message" en el error.');
   });
 });

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -103,7 +103,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
   }
 
   private async onCheckoutConfirm() {
-    const { selects } = this.modalService.getModalData();
+    const { selects } = this.modalService.getModalData()!;
     const [methodSelect, deliverySelect] = selects;
     const methodId = methodSelect.selected as number;
     const needsDelivery = deliverySelect.selected as boolean;

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
@@ -88,7 +88,7 @@ export class ConsultarDomicilioComponent implements OnInit {
             class: 'btn btn-success',
             action: () => {
               const modalData = this.modalService.getModalData();
-              if (modalData.select?.selected) {
+              if (modalData?.select?.selected) {
                 this.confirmarAsignacion(domicilio, modalData.select.selected);
                 this.modalService.closeModal();
               }

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -101,7 +101,7 @@ export class RutaDomicilioComponent implements OnInit {
             class: 'btn btn-success',
             action: () => {
               const modalData = this.modalService.getModalData();
-              if (modalData.select?.selected) {
+              if (modalData?.select?.selected) {
                 const metodoPagoSeleccionado = modalData.select.selected;
                 this.logger.log(LogLevel.INFO, 'Método de pago seleccionado:', metodoPagoSeleccionado);
                 this.domicilioService.updateDomicilio(this.domicilioId, {

--- a/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/app/shared/components/modal/modal.component.spec.ts
@@ -1,17 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ModalComponent } from './modal.component';
-import { ModalService } from '../../../core/services/modal.service';
+import { ModalService, ModalData } from '../../../core/services/modal.service';
 import { BehaviorSubject } from 'rxjs';
 
 describe('ModalComponent', () => {
   let component: ModalComponent;
   let fixture: ComponentFixture<ModalComponent>;
   let modalServiceSpy: any;
-  let modalDataSubject: BehaviorSubject<any>;
+  let modalDataSubject: BehaviorSubject<ModalData | null>;
   let isOpenSubject: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
-    modalDataSubject = new BehaviorSubject(null);
+    modalDataSubject = new BehaviorSubject<ModalData | null>(null);
     isOpenSubject = new BehaviorSubject(false);
     modalServiceSpy = {
       modalData$: modalDataSubject.asObservable(),
@@ -36,13 +36,14 @@ describe('ModalComponent', () => {
   });
 
   it('should update modalData when modalService emits new data', () => {
-    const testData = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const testData: ModalData = { title: 'Test Modal', message: 'Contenido de prueba' };
     modalDataSubject.next(testData);
     fixture.detectChanges();
     expect(component.modalData).toEqual(testData);
   });
 
   it('should update isOpen when modalService emits new state', () => {
+    modalDataSubject.next({ title: 'Test', message: 'Msg' });
     isOpenSubject.next(true);
     fixture.detectChanges();
     expect(component.isOpen).toBe(true);

--- a/src/app/shared/components/modal/modal.component.ts
+++ b/src/app/shared/components/modal/modal.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ModalService } from '../../../core/services/modal.service';
+import { ModalService, ModalData } from '../../../core/services/modal.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -12,7 +12,7 @@ import { FormsModule } from '@angular/forms';
 })
 export class ModalComponent implements OnInit {
   isOpen = false;
-  modalData: any = {};
+  modalData: ModalData | null = null;
 
   constructor(private modalService: ModalService) { }
 


### PR DESCRIPTION
## Summary
- define ModalData interface and use it throughout modal service
- type modal component and associated tests for ModalData
- improve modal logging and handle null data safely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ac91373483259c428fc07f02d559