### PR TITLE
refactor: migrate login to reactive forms

### DIFF
--- a/src/app/modules/auth/login/login.component.html
+++ b/src/app/modules/auth/login/login.component.html
@@ -4,22 +4,20 @@
             <div class="col-lg-6">
                 <h1 class="section-title text-center mt-5 mb-5">Iniciar Sesión</h1>
                 <div class="form-card-bg p-5">
-                    <form (ngSubmit)="onSubmit()" #loginForm="ngForm">
+                    <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
                         <div class="form-group">
                             <label for="documento">Documento</label>
-                            <input type="number" id="documento" name="documento" class="form-control"
-                                [(ngModel)]="documento" required #campoDocumento="ngModel" placeholder="1000000000"
-                                autocomplete="document" />
-                            <div *ngIf="campoDocumento.invalid && campoDocumento.touched" class="text-danger">
+                            <input type="number" id="documento" class="form-control"
+                                formControlName="documento" placeholder="1000000000" autocomplete="document" />
+                            <div *ngIf="loginForm.get('documento')?.invalid && loginForm.get('documento')?.touched" class="text-danger">
                                 El documento es obligatorio.
                             </div>
                         </div>
                         <div class="form-group mb-4">
                             <label for="password">Contraseña</label>
-                            <input type="password" id="password" name="password" class="form-control"
-                                autocomplete="current-password" [(ngModel)]="password" required #passwordField="ngModel"
-                                placeholder="******" />
-                            <div *ngIf="passwordField.invalid && passwordField.touched" class="text-danger">
+                            <input type="password" id="password" class="form-control"
+                                autocomplete="current-password" formControlName="password" placeholder="******" />
+                            <div *ngIf="loginForm.get('password')?.invalid && loginForm.get('password')?.touched" class="text-danger">
                                 La contraseña es obligatoria y debe tener al menos 6 caracteres.
                             </div>
                         </div>

--- a/src/app/modules/auth/login/login.component.spec.ts
+++ b/src/app/modules/auth/login/login.component.spec.ts
@@ -5,10 +5,10 @@ import { ToastrService } from 'ngx-toastr';
 import { UserService } from '../../../core/services/user.service';
 import { LoginComponent } from './login.component';
 import { of, throwError } from 'rxjs';
-import { FormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { mockLogin } from '../../../shared/mocks/login.mock';
-import { LoggingService } from '../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../core/services/logging.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -35,12 +35,11 @@ describe('LoginComponent', () => {
     } as unknown as jest.Mocked<ToastrService>;
 
     const loggingServiceMock = {
-      error: jest.fn(),
       log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
     await TestBed.configureTestingModule({
-      imports: [LoginComponent, FormsModule, CommonModule],
+      imports: [LoginComponent, ReactiveFormsModule, CommonModule],
       providers: [
         { provide: UserService, useValue: userServiceMock },
         { provide: Router, useValue: routerMock },
@@ -63,53 +62,56 @@ describe('LoginComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should call login service with correct credentials', () => {
-    userService.login.mockReturnValue(of(mockLoginResponse));
+    it('should call login service with correct credentials', () => {
+      userService.login.mockReturnValue(of(mockLoginResponse));
 
-    component.documento = mockLogin.documento;
-    component.password = mockLogin.password;
-    component.onSubmit();
+      component.loginForm.setValue(mockLogin);
+      component.onSubmit();
 
-    expect(userService.login).toHaveBeenCalledWith(mockLogin);
-    expect(userService.saveToken).toHaveBeenCalledWith('testToken');
-    expect(toastr.success).toHaveBeenCalledWith('Inicio de sesión exitoso', 'Bienvenido Test User');
-  });
+      expect(userService.login).toHaveBeenCalledWith(mockLogin);
+      expect(userService.saveToken).toHaveBeenCalledWith('testToken');
+      expect(toastr.success).toHaveBeenCalledWith('Inicio de sesión exitoso', 'Bienvenido Test User');
+    });
 
-  it('should navigate to admin route when user role is Administrador', () => {
-    userService.login.mockReturnValue(of(mockLoginResponse));
-    userService.getUserRole.mockReturnValue('Administrador');
+    it('should navigate to admin route when user role is Administrador', () => {
+      userService.login.mockReturnValue(of(mockLoginResponse));
+      userService.getUserRole.mockReturnValue('Administrador');
 
-    component.onSubmit();
+      component.loginForm.setValue(mockLogin);
+      component.onSubmit();
 
-    expect(router.navigate).toHaveBeenCalledWith(['/home']);
-  });
+      expect(router.navigate).toHaveBeenCalledWith(['/home']);
+    });
 
-  it('should navigate to client route when user role is cliente', () => {
-    userService.login.mockReturnValue(of(mockLoginResponse));
-    userService.getUserRole.mockReturnValue('Cliente');
+    it('should navigate to client route when user role is cliente', () => {
+      userService.login.mockReturnValue(of(mockLoginResponse));
+      userService.getUserRole.mockReturnValue('Cliente');
 
-    component.onSubmit();
+      component.loginForm.setValue(mockLogin);
+      component.onSubmit();
 
-    expect(router.navigate).toHaveBeenCalledWith(['/home']);
-  });
+      expect(router.navigate).toHaveBeenCalledWith(['/home']);
+    });
 
-  it('should handle login error and show toastr error message from service', () => {
-    const mockError = { message: 'Error de conexión' };
-    userService.login.mockReturnValue(throwError(() => mockError));
+    it('should handle login error and show toastr error message from service', () => {
+      const mockError = { message: 'Error de conexión' };
+      userService.login.mockReturnValue(throwError(() => mockError));
 
-    component.onSubmit();
+      component.loginForm.setValue(mockLogin);
+      component.onSubmit();
 
-    expect(toastr.error).toHaveBeenCalledWith('Error de conexión', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('err.message:', 'Error de conexión');
-  });
+      expect(toastr.error).toHaveBeenCalledWith('Error de conexión', 'Error de autenticación');
+      expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error de inicio de sesión', mockError);
+    });
 
-  it('should handle login error and show generic toastr error message when message is missing', () => {
-    const mockError = {};
-    userService.login.mockReturnValue(throwError(() => mockError));
+    it('should handle login error and show generic toastr error message when message is missing', () => {
+      const mockError = {};
+      userService.login.mockReturnValue(throwError(() => mockError));
 
-    component.onSubmit();
+      component.loginForm.setValue(mockLogin);
+      component.onSubmit();
 
-    expect(toastr.error).toHaveBeenCalledWith('Credenciales incorrectas', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('No hay propiedad "message" en el error.');
-  });
+      expect(toastr.error).toHaveBeenCalledWith('Credenciales incorrectas', 'Error de autenticación');
+      expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'No hay propiedad "message" en el error.');
+    });
 });

--- a/src/app/modules/auth/login/login.component.ts
+++ b/src/app/modules/auth/login/login.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { take } from 'rxjs';
@@ -13,22 +13,32 @@ import { environment } from '../../../../environments/environment';
   standalone: true,
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss'],
-  imports: [FormsModule, CommonModule],
+  imports: [ReactiveFormsModule, CommonModule],
 })
 export class LoginComponent {
-  documento: string = '';
-  password: string = '';
+  loginForm: FormGroup;
 
   constructor(
+    private fb: FormBuilder,
     private router: Router,
     private toastr: ToastrService,
     private userService: UserService,
     private logger: LoggingService
-  ) { }
+  ) {
+    this.loginForm = this.fb.group({
+      documento: ['', Validators.required],
+      password: ['', [Validators.required, Validators.minLength(6)]],
+    });
+  }
 
   onSubmit(): void {
+    if (this.loginForm.invalid) {
+      this.loginForm.markAllAsTouched();
+      return;
+    }
+
     this.userService
-      .login({ documento: this.documento, password: this.password })
+      .login(this.loginForm.value)
       .pipe(take(1))
       .subscribe({
         next: (response) => {
@@ -44,7 +54,10 @@ export class LoginComponent {
             if (err && err.message) {
               this.logger.log(LogLevel.ERROR, 'Error de inicio de sesión', err);
             } else {
-              this.logger.log(LogLevel.ERROR,'No hay propiedad "message" en el error.');
+              this.logger.log(
+                LogLevel.ERROR,
+                'No hay propiedad "message" en el error.'
+              );
             }
           }
           if (err && err.message) {

--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -14,6 +14,7 @@ import { ClienteService } from '../../../core/services/cliente.service';
 import { Router } from '@angular/router';
 
 import { Producto } from '../../../shared/models/producto.model';
+import { ToastrService } from 'ngx-toastr';
 
 describe('CarritoComponent', () => {
   let component: CarritoComponent;
@@ -29,6 +30,7 @@ describe('CarritoComponent', () => {
   let userServiceMock: any;
   let clienteServiceMock: any;
   let routerMock: any;
+  let toastrServiceMock: any;
 
   async function setup({
     items = [],
@@ -59,6 +61,7 @@ describe('CarritoComponent', () => {
     userServiceMock = { getUserId: jest.fn() };
     clienteServiceMock = { getClienteId: jest.fn() };
     routerMock = { navigate: jest.fn() };
+    toastrServiceMock = { success: jest.fn(), error: jest.fn() };
 
     await TestBed.configureTestingModule({
       imports: [CarritoComponent],
@@ -73,6 +76,7 @@ describe('CarritoComponent', () => {
         { provide: UserService, useValue: userServiceMock },
         { provide: ClienteService, useValue: clienteServiceMock },
         { provide: Router, useValue: routerMock },
+        { provide: ToastrService, useValue: toastrServiceMock },
       ],
     }).compileComponents();
 


### PR DESCRIPTION
## Summary
- replace template-driven forms with ReactiveFormsModule in login component
- implement `FormGroup` with `documento` and `password` controls and validators
- update specs and add missing ToastrService mock for cart component tests

## Testing
- `npm test` *(fails: Error: fail in carrito.component.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a3aca46b8483259832d19316cddaec