### PR TITLE
chore: use logging service in user service

### DIFF
--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -6,6 +6,7 @@ import { ApiResponse } from '../../shared/models/api-response.model';
 import { Login, LoginResponse } from '../../shared/models/login.model';
 import { HandleErrorService } from './handle-error.service';
 import { jwtDecode } from 'jwt-decode';
+import { LoggingService, LogLevel } from './logging.service';
 
 export interface DecodedToken {
   rol: string;
@@ -23,7 +24,7 @@ export class UserService {
 
   private authState = new BehaviorSubject<boolean>(this.isLoggedIn());
 
-  constructor(private http: HttpClient, private handleError: HandleErrorService) { }
+  constructor(private http: HttpClient, private handleError: HandleErrorService, private logger: LoggingService) { }
 
   getAuthState(): Observable<boolean> {
     return this.authState.asObservable();
@@ -55,7 +56,7 @@ export class UserService {
     try {
       return jwtDecode<DecodedToken>(token);
     } catch (error) {
-      console.error('Error al decodificar el token:', error);
+      this.logger.log(LogLevel.ERROR, 'Error al decodificar el token', error);
       return null;
     }
   }

--- a/src/app/modules/auth/login/login.component.spec.ts
+++ b/src/app/modules/auth/login/login.component.spec.ts
@@ -8,7 +8,7 @@ import { of, throwError } from 'rxjs';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { mockLogin } from '../../../shared/mocks/login.mock';
-import { LoggingService } from '../../../core/services/logging.service';
+import { LoggingService, LogLevel } from '../../../core/services/logging.service';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -35,7 +35,6 @@ describe('LoginComponent', () => {
     } as unknown as jest.Mocked<ToastrService>;
 
     const loggingServiceMock = {
-      error: jest.fn(),
       log: jest.fn()
     } as unknown as jest.Mocked<LoggingService>;
 
@@ -100,7 +99,7 @@ describe('LoginComponent', () => {
     component.onSubmit();
 
     expect(toastr.error).toHaveBeenCalledWith('Error de conexión', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('err.message:', 'Error de conexión');
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error de inicio de sesión', mockError);
   });
 
   it('should handle login error and show generic toastr error message when message is missing', () => {
@@ -110,6 +109,6 @@ describe('LoginComponent', () => {
     component.onSubmit();
 
     expect(toastr.error).toHaveBeenCalledWith('Credenciales incorrectas', 'Error de autenticación');
-    expect(loggingService.error).toHaveBeenCalledWith('No hay propiedad "message" en el error.');
+    expect(loggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'No hay propiedad "message" en el error.');
   });
 });


### PR DESCRIPTION
## Summary
- inject `LoggingService` into `UserService` and log token decode errors
- update unit tests to expect logger usage
- align login component tests with logger API

## Testing
- `npx jest src/app/core/services/user.service.spec.ts src/app/modules/auth/login/login.component.spec.ts`
- `npm test` *(fails: CarritoComponent tests cannot resolve ToastrService and related expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ac9deab083258c35eeefb382ebd2