### PR TITLE
refactor: finalizar getProductos al destruir componente

### DIFF
--- a/src/app/modules/public/ver-productos/ver-productos.component.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.ts
@@ -54,6 +54,7 @@ export class VerProductosComponent implements OnInit, OnDestroy {
   obtenerProductos(): void {
     this.productoService
       .getProductos({ onlyActive: true, includeImage: true })
+      .pipe(takeUntil(this.destroy$))
       .subscribe(response => {
         if (response.data) {
           this.productos = response.data;


### PR DESCRIPTION
## Summary
- encadena `takeUntil(this.destroy$)` en la petición de productos para finalizar el observable al destruir el componente

## Testing
- `npm test` *(fails: carrito.component.spec.ts: Jest worker encountered 4 child process exceptions)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d82ac9fc83258dea51b56ded613c