### PR TITLE
refactor modal to use typed details

### DIFF
--- a/src/app/core/services/modal.service.spec.ts
+++ b/src/app/core/services/modal.service.spec.ts
@@ -27,7 +27,7 @@ describe('ModalService', () => {
   });
 
   it('should update modalData and set isOpen to true when openModal is called', () => {
-    const data = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const data = { title: 'Test Modal', message: 'Contenido de prueba' };
     service.openModal(data);
 
     expect(service.getModalData()).toEqual(data);

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -1,19 +1,20 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { LoggingService, LogLevel } from './logging.service';
+import { ModalData } from '../../shared/models/modal.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ModalService {
-  private modalData = new BehaviorSubject<any>(null);
+  private modalData = new BehaviorSubject<ModalData | null>(null);
   modalData$ = this.modalData.asObservable();
   private isOpen = new BehaviorSubject<boolean>(false);
   isOpen$ = this.isOpen.asObservable();
 
   constructor(private logger: LoggingService) {}
 
-  openModal(data: any) {
+  openModal(data: ModalData) {
     this.logger.log(LogLevel.INFO, 'Entra');
     this.modalData.next(data);
     this.isOpen.next(true);
@@ -23,8 +24,8 @@ export class ModalService {
     this.isOpen.next(false);
   }
 
-  getModalData(): any {
+  getModalData(): ModalData {
     this.logger.log(LogLevel.INFO, 'getModalData');
-    return this.modalData.value;
+    return this.modalData.value as ModalData;
   }
 }

--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -225,7 +225,7 @@ describe('CarritoComponent', () => {
     component.carrito = [{ productoId: 1, nombre: 'P1', cantidad: 1, precio: 10 }];
     pedidoServiceMock.createPedido.mockReturnValue(throwError(() => new Error('fail')));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).finalizeOrder(3, null);
+    await (component as any).finalizeOrder(3, null).catch(() => {});
     expect(errorSpy).toHaveBeenCalled();
     expect(cartServiceMock.clearCart).not.toHaveBeenCalled();
     errorSpy.mockRestore();

--- a/src/app/modules/public/ver-productos/ver-productos.component.spec.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.spec.ts
@@ -226,7 +226,7 @@ describe('VerProductosComponent', () => {
 
     const args = modalService.openModal.mock.calls[0][0];
     expect(args.buttons.length).toBe(0);
-    expect(args.message).toContain('N/A');
+    expect(args.details.calorias).toBeUndefined();
   });
 });
 

--- a/src/app/modules/public/ver-productos/ver-productos.component.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.ts
@@ -147,13 +147,13 @@ export class VerProductosComponent implements OnInit, OnDestroy {
     this.modalService.openModal({
       title: producto.nombre,
       image: producto.imagen || '../../../../assets/img/logo2.png',
-      message: `
-      <strong>Precio:</strong> $${producto.precio}<br>
-      <strong>Calorías:</strong> ${producto.calorias || 'N/A'}<br>
-      <strong>Categoría:</strong> ${producto.categoria}<br>
-      <strong>Subcategoría:</strong> ${producto.subcategoria}<br>
-      <strong>Descripción:</strong> ${producto.descripcion || 'Sin descripción'}
-    `,
+      details: {
+        precio: producto.precio,
+        calorias: producto.calorias,
+        categoria: producto.categoria,
+        subcategoria: producto.subcategoria,
+        descripcion: producto.descripcion
+      },
       buttons: botones
     });
   }

--- a/src/app/shared/components/modal/modal.component.html
+++ b/src/app/shared/components/modal/modal.component.html
@@ -8,7 +8,15 @@
         <div class="modal-body">
             <img *ngIf="modalData.image" [src]="modalData.image" alt="Imagen modal" />
 
-            <div class="mt-3" *ngIf="modalData.message" [innerHTML]="modalData.message"></div>
+            <div class="mt-3" *ngIf="modalData.message">{{ modalData.message }}</div>
+
+            <div class="mt-3" *ngIf="modalData.details">
+                <p><strong>Precio:</strong> ${{ modalData.details.precio }}</p>
+                <p><strong>Calorías:</strong> {{ modalData.details.calorias || 'N/A' }}</p>
+                <p><strong>Categoría:</strong> {{ modalData.details.categoria }}</p>
+                <p><strong>Subcategoría:</strong> {{ modalData.details.subcategoria }}</p>
+                <p><strong>Descripción:</strong> {{ modalData.details.descripcion || 'Sin descripción' }}</p>
+            </div>
 
             <ng-container *ngIf="modalData.selects">
                 <div *ngFor="let sel of modalData.selects" class="form-group mt-3">

--- a/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/app/shared/components/modal/modal.component.spec.ts
@@ -36,7 +36,7 @@ describe('ModalComponent', () => {
   });
 
   it('should update modalData when modalService emits new data', () => {
-    const testData = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const testData = { title: 'Test Modal', message: 'Contenido de prueba' };
     modalDataSubject.next(testData);
     fixture.detectChanges();
     expect(component.modalData).toEqual(testData);

--- a/src/app/shared/components/modal/modal.component.ts
+++ b/src/app/shared/components/modal/modal.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ModalService } from '../../../core/services/modal.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ModalData } from '../../../shared/models/modal.model';
 
 @Component({
   selector: 'app-modal',
@@ -12,7 +13,7 @@ import { FormsModule } from '@angular/forms';
 })
 export class ModalComponent implements OnInit {
   isOpen = false;
-  modalData: any = {};
+  modalData: ModalData = {} as ModalData;
 
   constructor(private modalService: ModalService) { }
 

--- a/src/app/shared/models/modal.model.ts
+++ b/src/app/shared/models/modal.model.ts
@@ -1,0 +1,34 @@
+export interface ModalButton {
+    label: string;
+    class?: string;
+    action: () => void;
+}
+
+export interface ModalSelectOption {
+    label: string;
+    value: any;
+}
+
+export interface ModalSelect {
+    label: string;
+    options: ModalSelectOption[];
+    selected: any;
+}
+
+export interface ModalDetails {
+    precio: number;
+    calorias?: number;
+    categoria?: string;
+    subcategoria?: string;
+    descripcion?: string;
+}
+
+export interface ModalData {
+    title?: string;
+    image?: string;
+    message?: string;
+    details?: ModalDetails;
+    select?: ModalSelect;
+    selects?: ModalSelect[];
+    buttons?: ModalButton[];
+}


### PR DESCRIPTION
## Summary
- render modal messages with Angular bindings
- support typed modal data for product details
- show product details using structured data instead of raw HTML

## Testing
- `npm test` *(fails: CarritoComponent spec)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d8325f3083258bcf3787e43cb3f3