### PR TITLE
feat: add centralized error handling

### DIFF
--- a/src/app/core/services/pedido-cliente.service.spec.ts
+++ b/src/app/core/services/pedido-cliente.service.spec.ts
@@ -2,14 +2,24 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { PedidoClienteService } from './pedido-cliente.service';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 describe('PedidoClienteService', () => {
   let service: PedidoClienteService;
   let http: HttpTestingController;
   const baseUrl = `${environment.apiUrl}/pedido_clientes`;
+  const mockHandleErrorService = {
+    handleError: jest.fn((error: any) => { throw error; })
+  };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+    mockHandleErrorService.handleError.mockReset();
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: HandleErrorService, useValue: mockHandleErrorService }
+      ]
+    });
     service = TestBed.inject(PedidoClienteService);
     http = TestBed.inject(HttpTestingController);
   });
@@ -30,11 +40,32 @@ describe('PedidoClienteService', () => {
     req.flush(mock);
   });
 
+  it('handles error on create', () => {
+    const payload = { pedidoId: 1, clienteId: 2 } as any;
+    service.create(payload).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(baseUrl);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
   it('gets pedido cliente', () => {
     const mock = { code: 200, message: 'ok', data: {} };
     service.getPedidoCliente(3, 4).subscribe(res => expect(res).toEqual(mock));
     const req = http.expectOne(`${baseUrl}/3/4`);
     expect(req.request.method).toBe('GET');
     req.flush(mock);
+  });
+
+  it('handles error on getPedidoCliente', () => {
+    service.getPedidoCliente(3, 4).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}/3/4`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
   });
 });

--- a/src/app/core/services/pedido-cliente.service.ts
+++ b/src/app/core/services/pedido-cliente.service.ts
@@ -1,23 +1,28 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, catchError } from 'rxjs';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { environment } from '../../../environments/environment';
 import { PedidoCliente } from '../../shared/models/pedido-cliente.model';
+import { HandleErrorService } from './handle-error.service';
 
 
 @Injectable({ providedIn: 'root' })
 export class PedidoClienteService {
   private baseUrl = `${environment.apiUrl}/pedido_clientes`;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 
   /** Relaciona un pedido con un cliente */
   create(rel: PedidoCliente): Observable<ApiResponse<any>> {
-    return this.http.post<ApiResponse<any>>(this.baseUrl, rel);
+    return this.http.post<ApiResponse<any>>(this.baseUrl, rel).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
   /** Obtiene los pedidos de un cliente */
   getPedidoCliente(pedidoId: number, clienteId: number): Observable<ApiResponse<PedidoCliente>> {
-    return this.http.get<ApiResponse<PedidoCliente>>(`${this.baseUrl}/${pedidoId}/${clienteId}`);
+    return this.http.get<ApiResponse<PedidoCliente>>(`${this.baseUrl}/${pedidoId}/${clienteId}`).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 }

--- a/src/app/core/services/pedido.service.spec.ts
+++ b/src/app/core/services/pedido.service.spec.ts
@@ -2,14 +2,24 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { PedidoService } from './pedido.service';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 describe('PedidoService', () => {
   let service: PedidoService;
   let http: HttpTestingController;
   const baseUrl = `${environment.apiUrl}/pedidos`;
+  const mockHandleErrorService = {
+    handleError: jest.fn((error: any) => { throw error; })
+  };
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
+    mockHandleErrorService.handleError.mockReset();
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: HandleErrorService, useValue: mockHandleErrorService }
+      ]
+    });
     service = TestBed.inject(PedidoService);
     http = TestBed.inject(HttpTestingController);
   });
@@ -30,6 +40,17 @@ describe('PedidoService', () => {
     req.flush(mock);
   });
 
+  it('handles error on createPedido', () => {
+    const pedido = { total: 100 } as any;
+    service.createPedido(pedido).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(baseUrl);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
   it('assigns pago', () => {
     const mock = { code: 200, message: 'ok' };
     service.assignPago(1, 2).subscribe(res => expect(res).toEqual(mock));
@@ -37,6 +58,16 @@ describe('PedidoService', () => {
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toBeNull();
     req.flush(mock);
+  });
+
+  it('handles error on assignPago', () => {
+    service.assignPago(1, 2).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}/asignar-pago?pedido_id=1&pago_id=2`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
   });
 
   it('assigns domicilio', () => {
@@ -47,6 +78,16 @@ describe('PedidoService', () => {
     req.flush(mock);
   });
 
+  it('handles error on assignDomicilio', () => {
+    service.assignDomicilio(1, 3).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}/asignar-domicilio?pedido_id=1&domicilio_id=3`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
   it('gets mis pedidos', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service.getMisPedidos(5).subscribe(res => expect(res).toEqual(mock));
@@ -55,11 +96,31 @@ describe('PedidoService', () => {
     req.flush(mock);
   });
 
+  it('handles error on getMisPedidos', () => {
+    service.getMisPedidos(5).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}?cliente=5`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
   it('gets pedido detalles', () => {
     const mock = { code: 200, message: 'ok', data: {} };
     service.getPedidoDetalles(7).subscribe(res => expect(res).toEqual(mock));
     const req = http.expectOne(`${baseUrl}/detalles?pedido_id=7`);
     expect(req.request.method).toBe('GET');
     req.flush(mock);
+  });
+
+  it('handles error on getPedidoDetalles', () => {
+    service.getPedidoDetalles(7).subscribe({
+      next: () => fail('should have failed'),
+      error: err => expect(err).toBeTruthy()
+    });
+    const req = http.expectOne(`${baseUrl}/detalles?pedido_id=7`);
+    req.error(new ErrorEvent('Network error'));
+    expect(mockHandleErrorService.handleError).toHaveBeenCalled();
   });
 });

--- a/src/app/core/services/pedido.service.ts
+++ b/src/app/core/services/pedido.service.ts
@@ -1,18 +1,21 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, catchError } from 'rxjs';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Pedido } from '../../shared/models/pedido.model';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 @Injectable({ providedIn: 'root' })
 export class PedidoService {
   private baseUrl = `${environment.apiUrl}/pedidos`;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 
   createPedido(pedido: Partial<Pedido>): Observable<ApiResponse<Pedido>> {
-    return this.http.post<ApiResponse<Pedido>>(this.baseUrl, pedido);
+    return this.http.post<ApiResponse<Pedido>>(this.baseUrl, pedido).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   assignPago(pedidoId: number, pagoId: number): Observable<ApiResponse<any>> {
@@ -23,6 +26,8 @@ export class PedidoService {
       `${this.baseUrl}/asignar-pago`,
       null,
       { params }
+    ).pipe(
+      catchError(this.handleError.handleError)
     );
   }
 
@@ -34,16 +39,22 @@ export class PedidoService {
       `${this.baseUrl}/asignar-domicilio`,
       null,
       { params }
+    ).pipe(
+      catchError(this.handleError.handleError)
     );
   }
   getMisPedidos(clienteId: number): Observable<ApiResponse<Pedido[]>> {
     const params = new HttpParams().set('cliente', clienteId.toString());
-    return this.http.get<ApiResponse<Pedido[]>>(this.baseUrl, { params });
+    return this.http.get<ApiResponse<Pedido[]>>(this.baseUrl, { params }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
   getPedidoDetalles(pedidoId: number): Observable<any> {
     const params = new HttpParams().set('pedido_id', String(pedidoId));
-    return this.http.get<any>(`${this.baseUrl}/detalles`, { params });
+    return this.http.get<any>(`${this.baseUrl}/detalles`, { params }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 
 }

--- a/src/app/core/services/producto-pedido.service.ts
+++ b/src/app/core/services/producto-pedido.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, catchError } from 'rxjs';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { environment } from '../../../environments/environment';
+import { HandleErrorService } from './handle-error.service';
 
 interface DetalleProducto {
   PK_ID_PRODUCTO: number;
@@ -21,12 +22,14 @@ interface CrearProductoPedido {
 export class ProductoPedidoService {
   private baseUrl = `${environment.apiUrl}/producto_pedido`;
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private handleError: HandleErrorService) { }
 
   create(payload: CrearProductoPedido): Observable<ApiResponse<any>> {
     return this.http.post<ApiResponse<any>>(this.baseUrl, {
       PK_ID_PEDIDO: payload.PK_ID_PEDIDO,
       DETALLES_PRODUCTOS: JSON.stringify(payload.DETALLES_PRODUCTOS)
-    });
+    }).pipe(
+      catchError(this.handleError.handleError)
+    );
   }
 }

--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -114,9 +114,11 @@ describe('CarritoComponent', () => {
 
   it('should unsubscribe on destroy', async () => {
     await setup();
-    const spy = jest.spyOn((component as any).sub, 'unsubscribe');
+    const nextSpy = jest.spyOn((component as any).destroy$, 'next');
+    const completeSpy = jest.spyOn((component as any).destroy$, 'complete');
     component.ngOnDestroy();
-    expect(spy).toHaveBeenCalled();
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
   });
 
   it('should interact with cart service for item operations', async () => {
@@ -146,8 +148,8 @@ describe('CarritoComponent', () => {
   it('should finalize order without delivery', async () => {
     await setup();
     modalServiceMock.getModalData.mockReturnValue({ selects: [{ selected: 2 }, { selected: false }] });
-    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
-    (component as any).onCheckoutConfirm();
+    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockResolvedValue(undefined);
+    await (component as any).onCheckoutConfirm();
     expect(modalServiceMock.closeModal).toHaveBeenCalled();
     expect(finalizeSpy).toHaveBeenCalledWith(2, null);
   });
@@ -158,8 +160,8 @@ describe('CarritoComponent', () => {
     userServiceMock.getUserId.mockReturnValue(77);
     clienteServiceMock.getClienteId.mockReturnValue(of({ data: { direccion: 'dir', telefono: 'tel', observaciones: '' } }));
     domicilioServiceMock.createDomicilio.mockReturnValue(of({ data: { domicilioId: 9 } }));
-    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
-    (component as any).onCheckoutConfirm();
+    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockResolvedValue(undefined);
+    await (component as any).onCheckoutConfirm();
     expect(clienteServiceMock.getClienteId).toHaveBeenCalledWith(77);
     expect(domicilioServiceMock.createDomicilio).toHaveBeenCalled();
     expect(finalizeSpy).toHaveBeenCalledWith(3, 9);
@@ -170,9 +172,9 @@ describe('CarritoComponent', () => {
     modalServiceMock.getModalData.mockReturnValue({ selects: [{ selected: 1 }, { selected: true }] });
     userServiceMock.getUserId.mockReturnValue(10);
     clienteServiceMock.getClienteId.mockReturnValue(throwError(() => new Error('fail')));
-    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
+    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockResolvedValue(undefined);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).onCheckoutConfirm();
+    await (component as any).onCheckoutConfirm().catch(() => {});
     expect(finalizeSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledTimes(2);
     errorSpy.mockRestore();
@@ -184,9 +186,9 @@ describe('CarritoComponent', () => {
     userServiceMock.getUserId.mockReturnValue(20);
     clienteServiceMock.getClienteId.mockReturnValue(of({ data: { direccion: 'a', telefono: 'b', observaciones: '' } }));
     domicilioServiceMock.createDomicilio.mockReturnValue(throwError(() => new Error('dom fail')));
-    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
+    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockResolvedValue(undefined);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).onCheckoutConfirm();
+    await (component as any).onCheckoutConfirm().catch(() => {});
     expect(finalizeSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledTimes(2);
     errorSpy.mockRestore();
@@ -201,7 +203,7 @@ describe('CarritoComponent', () => {
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
     pedidoServiceMock.assignPago.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
-    (component as any).finalizeOrder(1, null);
+    await (component as any).finalizeOrder(1, null);
     expect(pedidoServiceMock.assignDomicilio).not.toHaveBeenCalled();
     expect(cartServiceMock.clearCart).toHaveBeenCalled();
     expect(routerMock.navigate).toHaveBeenCalledWith(['/cliente/mis-pedidos']);
@@ -216,7 +218,7 @@ describe('CarritoComponent', () => {
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
     pedidoServiceMock.assignPago.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
-    (component as any).finalizeOrder(2, 7);
+    await (component as any).finalizeOrder(2, 7);
     expect(pedidoServiceMock.assignDomicilio).toHaveBeenCalledWith(50, 7);
   });
 
@@ -225,7 +227,7 @@ describe('CarritoComponent', () => {
     component.carrito = [{ productoId: 1, nombre: 'P1', cantidad: 1, precio: 10 }];
     pedidoServiceMock.createPedido.mockReturnValue(throwError(() => new Error('fail')));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).finalizeOrder(3, null);
+    await (component as any).finalizeOrder(3, null).catch(() => {});
     expect(errorSpy).toHaveBeenCalled();
     expect(cartServiceMock.clearCart).not.toHaveBeenCalled();
     errorSpy.mockRestore();


### PR DESCRIPTION
## Summary
- inject HandleErrorService into pedido-related services
- pipe HTTP calls through centralized catchError handlers
- expand unit tests for services and carrito component error flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3d850676c8325ba03c382178bb857