### PR TITLE
refactor modal to use typed details

### DIFF
--- a/src/app/core/services/modal.service.spec.ts
+++ b/src/app/core/services/modal.service.spec.ts
@@ -27,7 +27,7 @@ describe('ModalService', () => {
   });
 
   it('should update modalData and set isOpen to true when openModal is called', () => {
-    const data = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const data = { title: 'Test Modal', message: 'Contenido de prueba' };
     service.openModal(data);
 
     expect(service.getModalData()).toEqual(data);

--- a/src/app/core/services/modal.service.ts
+++ b/src/app/core/services/modal.service.ts
@@ -1,19 +1,20 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { LoggingService, LogLevel } from './logging.service';
+import { ModalData } from '../../shared/models/modal.model';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ModalService {
-  private modalData = new BehaviorSubject<any>(null);
+  private modalData = new BehaviorSubject<ModalData | null>(null);
   modalData$ = this.modalData.asObservable();
   private isOpen = new BehaviorSubject<boolean>(false);
   isOpen$ = this.isOpen.asObservable();
 
   constructor(private logger: LoggingService) {}
 
-  openModal(data: any) {
+  openModal(data: ModalData) {
     this.logger.log(LogLevel.INFO, 'Entra');
     this.modalData.next(data);
     this.isOpen.next(true);
@@ -23,8 +24,8 @@ export class ModalService {
     this.isOpen.next(false);
   }
 
-  getModalData(): any {
+  getModalData(): ModalData {
     this.logger.log(LogLevel.INFO, 'getModalData');
-    return this.modalData.value;
+    return this.modalData.value as ModalData;
   }
 }

--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -114,9 +114,11 @@ describe('CarritoComponent', () => {
 
   it('should unsubscribe on destroy', async () => {
     await setup();
-    const spy = jest.spyOn((component as any).sub, 'unsubscribe');
+    const nextSpy = jest.spyOn((component as any).destroy$, 'next');
+    const completeSpy = jest.spyOn((component as any).destroy$, 'complete');
     component.ngOnDestroy();
-    expect(spy).toHaveBeenCalled();
+    expect(nextSpy).toHaveBeenCalled();
+    expect(completeSpy).toHaveBeenCalled();
   });
 
   it('should interact with cart service for item operations', async () => {
@@ -159,7 +161,7 @@ describe('CarritoComponent', () => {
     clienteServiceMock.getClienteId.mockReturnValue(of({ data: { direccion: 'dir', telefono: 'tel', observaciones: '' } }));
     domicilioServiceMock.createDomicilio.mockReturnValue(of({ data: { domicilioId: 9 } }));
     const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
-    (component as any).onCheckoutConfirm();
+    await (component as any).onCheckoutConfirm();
     expect(clienteServiceMock.getClienteId).toHaveBeenCalledWith(77);
     expect(domicilioServiceMock.createDomicilio).toHaveBeenCalled();
     expect(finalizeSpy).toHaveBeenCalledWith(3, 9);
@@ -172,7 +174,7 @@ describe('CarritoComponent', () => {
     clienteServiceMock.getClienteId.mockReturnValue(throwError(() => new Error('fail')));
     const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).onCheckoutConfirm();
+    await (component as any).onCheckoutConfirm().catch(() => {});
     expect(finalizeSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledTimes(2);
     errorSpy.mockRestore();
@@ -186,7 +188,7 @@ describe('CarritoComponent', () => {
     domicilioServiceMock.createDomicilio.mockReturnValue(throwError(() => new Error('dom fail')));
     const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).onCheckoutConfirm();
+    await (component as any).onCheckoutConfirm().catch(() => {});
     expect(finalizeSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledTimes(2);
     errorSpy.mockRestore();
@@ -201,7 +203,7 @@ describe('CarritoComponent', () => {
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
     pedidoServiceMock.assignPago.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
-    (component as any).finalizeOrder(1, null);
+    await (component as any).finalizeOrder(1, null);
     expect(pedidoServiceMock.assignDomicilio).not.toHaveBeenCalled();
     expect(cartServiceMock.clearCart).toHaveBeenCalled();
     expect(routerMock.navigate).toHaveBeenCalledWith(['/cliente/mis-pedidos']);
@@ -216,7 +218,7 @@ describe('CarritoComponent', () => {
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
     pedidoServiceMock.assignPago.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
-    (component as any).finalizeOrder(2, 7);
+    await (component as any).finalizeOrder(2, 7);
     expect(pedidoServiceMock.assignDomicilio).toHaveBeenCalledWith(50, 7);
   });
 
@@ -225,7 +227,7 @@ describe('CarritoComponent', () => {
     component.carrito = [{ productoId: 1, nombre: 'P1', cantidad: 1, precio: 10 }];
     pedidoServiceMock.createPedido.mockReturnValue(throwError(() => new Error('fail')));
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-    (component as any).finalizeOrder(3, null);
+    await (component as any).finalizeOrder(3, null).catch(() => {});
     expect(errorSpy).toHaveBeenCalled();
     expect(cartServiceMock.clearCart).not.toHaveBeenCalled();
     errorSpy.mockRestore();

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -104,7 +104,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
 
   private async onCheckoutConfirm() {
     const { selects } = this.modalService.getModalData();
-    const [methodSelect, deliverySelect] = selects;
+    const [methodSelect, deliverySelect] = selects!;
     const methodId = methodSelect.selected as number;
     const needsDelivery = deliverySelect.selected as boolean;
 

--- a/src/app/modules/public/ver-productos/ver-productos.component.spec.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.spec.ts
@@ -226,7 +226,7 @@ describe('VerProductosComponent', () => {
 
     const args = modalService.openModal.mock.calls[0][0];
     expect(args.buttons.length).toBe(0);
-    expect(args.message).toContain('N/A');
+    expect(args.details.calorias).toBeUndefined();
   });
 });
 

--- a/src/app/modules/public/ver-productos/ver-productos.component.ts
+++ b/src/app/modules/public/ver-productos/ver-productos.component.ts
@@ -146,14 +146,14 @@ export class VerProductosComponent implements OnInit, OnDestroy {
 
     this.modalService.openModal({
       title: producto.nombre,
-      image: producto.imagen || '../../../../assets/img/logo2.png',
-      message: `
-      <strong>Precio:</strong> $${producto.precio}<br>
-      <strong>Calorías:</strong> ${producto.calorias || 'N/A'}<br>
-      <strong>Categoría:</strong> ${producto.categoria}<br>
-      <strong>Subcategoría:</strong> ${producto.subcategoria}<br>
-      <strong>Descripción:</strong> ${producto.descripcion || 'Sin descripción'}
-    `,
+      image: typeof producto.imagen === 'string' ? producto.imagen : '../../../../assets/img/logo2.png',
+      details: {
+        precio: producto.precio,
+        calorias: producto.calorias,
+        categoria: producto.categoria,
+        subcategoria: producto.subcategoria,
+        descripcion: producto.descripcion
+      },
       buttons: botones
     });
   }

--- a/src/app/shared/components/modal/modal.component.html
+++ b/src/app/shared/components/modal/modal.component.html
@@ -8,7 +8,15 @@
         <div class="modal-body">
             <img *ngIf="modalData.image" [src]="modalData.image" alt="Imagen modal" />
 
-            <div class="mt-3" *ngIf="modalData.message" [innerHTML]="modalData.message"></div>
+            <div class="mt-3" *ngIf="modalData.message">{{ modalData.message }}</div>
+
+            <div class="mt-3" *ngIf="modalData.details">
+                <p><strong>Precio:</strong> ${{ modalData.details.precio }}</p>
+                <p><strong>Calorías:</strong> {{ modalData.details.calorias || 'N/A' }}</p>
+                <p><strong>Categoría:</strong> {{ modalData.details.categoria }}</p>
+                <p><strong>Subcategoría:</strong> {{ modalData.details.subcategoria }}</p>
+                <p><strong>Descripción:</strong> {{ modalData.details.descripcion || 'Sin descripción' }}</p>
+            </div>
 
             <ng-container *ngIf="modalData.selects">
                 <div *ngFor="let sel of modalData.selects" class="form-group mt-3">

--- a/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/app/shared/components/modal/modal.component.spec.ts
@@ -36,7 +36,7 @@ describe('ModalComponent', () => {
   });
 
   it('should update modalData when modalService emits new data', () => {
-    const testData = { title: 'Test Modal', content: 'Contenido de prueba' };
+    const testData = { title: 'Test Modal', message: 'Contenido de prueba' };
     modalDataSubject.next(testData);
     fixture.detectChanges();
     expect(component.modalData).toEqual(testData);

--- a/src/app/shared/components/modal/modal.component.ts
+++ b/src/app/shared/components/modal/modal.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ModalService } from '../../../core/services/modal.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { ModalData } from '../../../shared/models/modal.model';
 
 @Component({
   selector: 'app-modal',
@@ -12,7 +13,7 @@ import { FormsModule } from '@angular/forms';
 })
 export class ModalComponent implements OnInit {
   isOpen = false;
-  modalData: any = {};
+  modalData: ModalData = {} as ModalData;
 
   constructor(private modalService: ModalService) { }
 

--- a/src/app/shared/models/modal.model.ts
+++ b/src/app/shared/models/modal.model.ts
@@ -1,0 +1,34 @@
+export interface ModalButton {
+    label: string;
+    class?: string;
+    action: () => void;
+}
+
+export interface ModalSelectOption {
+    label: string;
+    value: any;
+}
+
+export interface ModalSelect {
+    label: string;
+    options: ModalSelectOption[];
+    selected: any;
+}
+
+export interface ModalDetails {
+    precio: number;
+    calorias?: number;
+    categoria?: string;
+    subcategoria?: string;
+    descripcion?: string;
+}
+
+export interface ModalData {
+    title?: string;
+    image?: string;
+    message?: string;
+    details?: ModalDetails;
+    select?: ModalSelect;
+    selects?: ModalSelect[];
+    buttons?: ModalButton[];
+}


### PR DESCRIPTION
## Summary
- render modal messages with Angular bindings
- support typed modal data for product details
- show product details using structured data instead of raw HTML
- fix optional select destructure and image typing
- update carrito component tests for async flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8325f3083258bcf3787e43cb3f3