### PR TITLE
feat(cliente): detalle de pedido para clientes

### DIFF
--- a/src/app/modules/client/client.routes.spec.ts
+++ b/src/app/modules/client/client.routes.spec.ts
@@ -2,6 +2,7 @@ import { clientRoutes } from './client.routes';
 import { CarritoComponent } from './carrito/carrito.component';
 import { MisPedidosComponent } from './mis-pedidos/mis-pedidos.component';
 import { PerfilComponent } from './perfil/perfil.component';
+import { PedidoComponent } from './pedido/pedido.component';
 import { AuthGuard } from '../../core/guards/auth.guard';
 import { RoleGuard } from '../../core/guards/role.guard';
 
@@ -16,6 +17,13 @@ describe('Client Routes', () => {
   it('should map mis-pedidos with guards', () => {
     const route = clientRoutes.find(r => r.path === 'mis-pedidos');
     expect(route?.component).toBe(MisPedidosComponent);
+    expect(route?.canActivate).toEqual([AuthGuard, RoleGuard]);
+    expect(route?.data).toEqual({ roles: ['Cliente'] });
+  });
+
+  it('should map pedido/:id with guards', () => {
+    const route = clientRoutes.find(r => r.path === 'pedido/:id');
+    expect(route?.component).toBe(PedidoComponent);
     expect(route?.canActivate).toEqual([AuthGuard, RoleGuard]);
     expect(route?.data).toEqual({ roles: ['Cliente'] });
   });

--- a/src/app/modules/client/client.routes.ts
+++ b/src/app/modules/client/client.routes.ts
@@ -4,6 +4,7 @@ import { RoleGuard } from '../../core/guards/role.guard';
 import { CarritoComponent } from './carrito/carrito.component';
 import { MisPedidosComponent } from './mis-pedidos/mis-pedidos.component';
 import { PerfilComponent } from './perfil/perfil.component';
+import { PedidoComponent } from './pedido/pedido.component';
 
 export const clientRoutes: Routes = [
     {
@@ -19,6 +20,13 @@ export const clientRoutes: Routes = [
         canActivate: [AuthGuard, RoleGuard],
         data: { roles: ['Cliente'] },
         title: 'Mis pedidos',
+    },
+    {
+        path: 'pedido/:id',
+        component: PedidoComponent,
+        canActivate: [AuthGuard, RoleGuard],
+        data: { roles: ['Cliente'] },
+        title: 'Detalle del pedido',
     },
     {
         path: 'perfil',

--- a/src/app/modules/client/pedido/pedido.component.html
+++ b/src/app/modules/client/pedido/pedido.component.html
@@ -1,0 +1,76 @@
+<div class="container-fluid mt-4">
+  <div class="container">
+    <a class="back-link" routerLink="/cliente/mis-pedidos">&larr; Volver</a>
+
+    <h1 class="text-center mb-4">Detalle del pedido</h1>
+
+    @if (loading) {
+      <div class="text-center text-muted">Cargando pedido…</div>
+    }
+
+    @if (error) {
+      <div class="alert alert-danger">{{ error }}</div>
+    }
+
+    @if (!loading && pedido) {
+      <article class="pedido-card">
+        <header class="pedido-card__header">
+          <div class="pedido-card__title">
+            <h3 class="pedido-card__id">Pedido #{{ pedido.PK_ID_PEDIDO }}</h3>
+            <div class="pedido-card__tags">
+              <span class="tag" [ngClass]="{
+                'tag--ok': pedido.ESTADO_PEDIDO === 'TERMINADO',
+                'tag--warn': pedido.ESTADO_PEDIDO === 'INICIADO',
+                'tag--danger': pedido.ESTADO_PEDIDO === 'CANCELADO'
+              }">{{ pedido.ESTADO_PEDIDO }}</span>
+              <span class="tag" [ngClass]="{ 'tag--muted': !pedido.DELIVERY }">{{ pedido.DELIVERY ? 'Domicilio' : 'En restaurante' }}</span>
+            </div>
+          </div>
+        </header>
+
+        <div class="pedido-card__meta">
+          <div class="meta__item">
+            <span class="meta__label">Fecha</span>
+            <span class="meta__value">{{ pedido.FECHA | formatDate:'date' }}</span>
+          </div>
+          <div class="meta__item">
+            <span class="meta__label">Hora</span>
+            <span class="meta__value">{{ pedido.HORA | formatDate:'time' }}</span>
+          </div>
+          <div class="meta__item">
+            <span class="meta__label">Método de pago</span>
+            <span class="meta__value">{{ pedido.METODO_PAGO }}</span>
+          </div>
+        </div>
+
+        <div class="pedido-detalle__productos">
+          <h3 class="pedido-detalle__subtitle">Productos</h3>
+          <table class="table table-striped">
+            <thead>
+              <tr>
+                <th>Nombre</th>
+                <th>Cant.</th>
+                <th>Subtotal</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (prod of pedido.PRODUCTOS; track prod.NOMBRE; let i = $index) {
+                <tr>
+                  <td>{{ prod.NOMBRE || prod.nombre }}</td>
+                  <td>{{ prod.CANTIDAD || prod.cantidad }}</td>
+                  <td>
+                    ${{ (prod.SUBTOTAL ?? (prod.PRECIO_UNITARIO || prod.precio || 0) * (prod.CANTIDAD || prod.cantidad || 1)) | number:'1.0-0' }}
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+
+        <footer class="pedido-card__footer">
+          <span class="pedido-detalle__total">Total: ${{ pedido.total | number:'1.0-0' }}</span>
+        </footer>
+      </article>
+    }
+  </div>
+</div>

--- a/src/app/modules/client/pedido/pedido.component.scss
+++ b/src/app/modules/client/pedido/pedido.component.scss
@@ -1,0 +1,108 @@
+@use '../../../../assets/styles.scss' as *;
+
+.container {
+  max-width: 960px;
+}
+
+.pedido-card {
+  border: 1px solid $primary;
+  border-radius: 16px;
+  background: $white;
+  padding: 16px;
+  display: grid;
+  gap: 16px;
+}
+
+.pedido-card__header {
+  display: grid;
+  gap: 8px;
+}
+
+.pedido-card__title {
+  display: grid;
+  gap: 4px;
+}
+
+.pedido-card__id {
+  margin: 0;
+  font-weight: 700;
+  color: $secondary;
+}
+
+.pedido-card__tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: .8rem;
+  background: $light;
+  border: 1px solid $quaternary;
+  color: $dark;
+}
+
+.tag--ok {
+  color: $success;
+  border-color: $success;
+  background: rgba(17, 228, 10, 0.06);
+}
+
+.tag--warn {
+  color: $warning;
+  border-color: $warning;
+  background: rgba(255, 193, 7, .1);
+}
+
+.tag--danger {
+  color: $danger;
+  border-color: $danger;
+  background: rgba(220, 53, 69, .08);
+}
+
+.tag--muted {
+  color: $primary;
+  border-color: $primary;
+  background: rgba(0, 0, 0, .03);
+}
+
+.pedido-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 8px;
+}
+
+.meta__item {
+  display: grid;
+  gap: 1px;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, .02);
+}
+
+.meta__label {
+  font-size: .75rem;
+  opacity: .7;
+}
+
+.meta__value {
+  font-weight: 600;
+}
+
+.pedido-card__footer {
+  display: flex;
+  justify-content: flex-end;
+  font-weight: 600;
+}
+
+.back-link {
+  font-weight: 600;
+  color: $primary;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/app/modules/client/pedido/pedido.component.spec.ts
+++ b/src/app/modules/client/pedido/pedido.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { convertToParamMap, ActivatedRoute } from '@angular/router';
+
+import { PedidoComponent } from './pedido.component';
+import { PedidoService } from '../../../core/services/pedido.service';
+
+describe('PedidoComponent', () => {
+  let component: PedidoComponent;
+  let fixture: ComponentFixture<PedidoComponent>;
+  let pedidoService: { getPedidoDetalles: jest.Mock };
+
+  beforeEach(async () => {
+    pedidoService = { getPedidoDetalles: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [PedidoComponent],
+      providers: [
+        { provide: PedidoService, useValue: pedidoService },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ id: '5' }) } } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PedidoComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load pedido on init', () => {
+    pedidoService.getPedidoDetalles.mockReturnValue(of({ data: { PK_ID_PEDIDO: 5, PRODUCTOS: '[]', METODO_PAGO: 'Nequi', FECHA: '01-01-2024', HORA: '0000-01-01 10:00:00 +0000 UTC', DELIVERY: true, ESTADO_PEDIDO: 'TERMINADO' } }));
+    component.ngOnInit();
+    expect(pedidoService.getPedidoDetalles).toHaveBeenCalledWith(5);
+    expect(component.loading).toBe(false);
+    expect(component.pedido.METODO_PAGO).toBe('Nequi');
+  });
+
+  it('should handle error on load', () => {
+    pedidoService.getPedidoDetalles.mockReturnValue(throwError(() => new Error('fail')));
+    component.ngOnInit();
+    expect(component.error).toBe('Error al cargar el pedido');
+    expect(component.loading).toBe(false);
+  });
+});

--- a/src/app/modules/client/pedido/pedido.component.ts
+++ b/src/app/modules/client/pedido/pedido.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+
+import { PedidoService } from '../../../core/services/pedido.service';
+import { FormatDatePipe } from '../../../shared/pipes/format-date.pipe';
+
+@Component({
+  selector: 'app-pedido',
+  standalone: true,
+  imports: [CommonModule, RouterLink, FormatDatePipe],
+  templateUrl: './pedido.component.html',
+  styleUrls: ['./pedido.component.scss']
+})
+export class PedidoComponent implements OnInit {
+  pedido: any;
+  loading = true;
+  error = '';
+
+  constructor(
+    private route: ActivatedRoute,
+    private pedidoService: PedidoService
+  ) { }
+
+  ngOnInit(): void {
+    const id = Number(this.route.snapshot.paramMap.get('id'));
+    if (!id) {
+      this.error = 'Pedido no encontrado';
+      this.loading = false;
+      return;
+    }
+
+    this.pedidoService.getPedidoDetalles(id).subscribe({
+      next: res => {
+        const det = res?.data;
+        if (det) {
+          let productos: any[] = [];
+          try {
+            const parsed = det.PRODUCTOS ? JSON.parse(det.PRODUCTOS) : [];
+            productos = Array.isArray(parsed) ? parsed : [];
+          } catch {
+            productos = [];
+          }
+          const total = productos.reduce((acc, it) => {
+            const sub = Number(it.SUBTOTAL ?? it.subtotal ?? ((Number(it.PRECIO_UNITARIO ?? it.precio ?? 0)) * (Number(it.CANTIDAD ?? it.cantidad ?? 1))));
+            return acc + (isNaN(sub) ? 0 : sub);
+          }, 0);
+          this.pedido = { ...det, PRODUCTOS: productos, total };
+        }
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Error al cargar el pedido';
+        this.loading = false;
+      }
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- agregar PedidoComponent para mostrar detalle de un pedido
- enrutar /cliente/pedido/:id con protección por roles
- pruebas para la nueva ruta y componente

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3dce307388325bcbcce249b3d5876