### PR TITLE
fix: correct quaternary color variable

### DIFF
--- a/src/app/modules/client/carrito/carrito.component.scss
+++ b/src/app/modules/client/carrito/carrito.component.scss
@@ -24,7 +24,7 @@
     padding: 0.25rem 0.5rem;
     font-size: 1.25rem;
     line-height: 1;
-    color: var(--qaternary);
+    color: var(--quaternary);
     cursor: pointer;
     transition: color 0.2s ease;
 


### PR DESCRIPTION
## Summary
- fix button icon color to use `var(--quaternary)`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm run lint:scss` *(fails: 434 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3dfb4842c83259de30d8a24036ae2