### PR TITLE
refactor: standardize style imports

### DIFF
--- a/src/app/shared/components/footer/footer.component.scss
+++ b/src/app/shared/components/footer/footer.component.scss
@@ -1,1 +1,1 @@
-@use "../../../../assets/styles";
+@use "../../../../assets/styles.scss" as *;

--- a/src/app/shared/components/modal/modal.component.scss
+++ b/src/app/shared/components/modal/modal.component.scss
@@ -1,3 +1,5 @@
+@use "../../../../assets/styles.scss" as *;
+
 .modal-overlay {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- align footer component with header by importing global styles using `@use "../../../../assets/styles.scss" as *`
- add missing global style import to modal component

## Testing
- `npm run lint:scss` *(fails: 434 problems)*
- `npm test -- --runInBand --forceExit`


------
https://chatgpt.com/codex/tasks/task_e_68a3dfb906a48325836515faa77aaeed