### PR TITLE
refactor: replace hex colors with palette variables

### DIFF
--- a/src/app/modules/client/perfil/perfil.component.scss
+++ b/src/app/modules/client/perfil/perfil.component.scss
@@ -174,7 +174,4 @@
 }
 
 .state__box--warn {
-  // background: #fff3cd;
-  //border-color: #ffe69c;
-  //color: #8a6d3b;
 }

--- a/src/app/modules/public/page-not-found/page-not-found.component.scss
+++ b/src/app/modules/public/page-not-found/page-not-found.component.scss
@@ -87,7 +87,7 @@ a {
 @keyframes dash {
   0%,
   30% {
-    fill: #4b4b62;
+    fill: var(--gray-dark);
     stroke-dashoffset: 0;
   }
 

--- a/src/app/modules/public/ubicacion-restaurante/ubicacion-restaurante.component.scss
+++ b/src/app/modules/public/ubicacion-restaurante/ubicacion-restaurante.component.scss
@@ -34,7 +34,7 @@
 }
 
 .info-card p {
-  color: #555;
+  color: $gray;
   font-size: 1rem;
 }
 

--- a/src/app/modules/public/ver-productos/ver-productos.component.scss
+++ b/src/app/modules/public/ver-productos/ver-productos.component.scss
@@ -43,7 +43,7 @@
 
         .producto-precio {
             font-size: 1rem;
-            color: #28a745;
+            color: $green;
             font-weight: bold;
         }
     }
@@ -97,9 +97,9 @@
 }
 
 .form-group {
-    label {
+        label {
         margin-bottom: 4px;
-        color: #333;
+        color: $dark;
     }
 
     input,
@@ -109,8 +109,8 @@
 }
 
 .filtros-card {
-    border: 1px solid #dee2e6;
-    background-color: #ffffff;
+    border: 1px solid var(--gray);
+    background-color: $white;
     border-radius: 20px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.scss
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.scss
@@ -29,7 +29,7 @@
 }
 
 .info-card p {
-  color: #555;
+  color: $gray;
   font-size: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- replace hard-coded hex colors with palette variables
- clean up unused hex references

## Testing
- `npm test`
- `npm run lint:scss` *(fails: numerous existing stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dfaca2ac832585433d3bb5423684