### PR TITLE
fix: update Sass modules for compatibility

### DIFF
--- a/src/assets/_base.scss
+++ b/src/assets/_base.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 :root {
   --blue: #{$blue};
   --indigo: #{$indigo};

--- a/src/assets/_utilities.scss
+++ b/src/assets/_utilities.scss
@@ -1,3 +1,6 @@
+@use 'variables' as *;
+@use "sass:color";
+
 .text-monospace {
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;
 }

--- a/src/assets/styles.scss
+++ b/src/assets/styles.scss
@@ -1,3 +1,3 @@
-@import 'variables';
-@import 'base';
-@import 'utilities';
+@forward 'variables';
+@forward 'base';
+@forward 'utilities';


### PR DESCRIPTION
## Summary
- replace deprecated `@import` with `@forward` in global styles
- ensure base and utilities load shared variables
- add missing `sass:color` module so `color.adjust` works

## Testing
- `npm run lint:scss` *(fails: many stylelint rule violations)*
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4e7f17d0c83259ba643409b7d95d4