### PR TITLE
refactor: simplify modal styles

### DIFF
--- a/src/app/shared/components/modal/modal.component.scss
+++ b/src/app/shared/components/modal/modal.component.scss
@@ -14,7 +14,7 @@
 }
 
 .modal-content {
-    background: white;
+    background: $white;
     padding: 20px;
     border-radius: 8px;
     width: 90%;
@@ -43,28 +43,6 @@
     display: flex;
     justify-content: space-around;
     margin-top: 15px;
-}
-
-.modal-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-}
-
-.modal-content {
-    background: white;
-    padding: 20px;
-    border-radius: 8px;
-    width: 90%;
-    max-width: 500px;
-    box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.3);
 }
 
 .modal-body img {


### PR DESCRIPTION
## Summary
- remove duplicate modal overlay and content styles
- use global `$white` variable for modal background

## Testing
- `npm run lint:scss` (fails: 430 errors)
- `npm test` (fails: mis-pedidos.component.spec.ts)


------
https://chatgpt.com/codex/tasks/task_e_68a4f0eb16708325bd73d1995aac471f