### PR TITLE
fix: use min-width for responsive utilities

### DIFF
--- a/src/assets/_utilities.scss
+++ b/src/assets/_utilities.scss
@@ -35,7 +35,7 @@
   text-align: center !important;
 }
 
-@media (width >=576px) {
+@media (min-width: 576px) {
   .text-sm-left {
     text-align: left !important;
   }
@@ -49,7 +49,7 @@
   }
 }
 
-@media (width >=768px) {
+@media (min-width: 768px) {
   .text-md-left {
     text-align: left !important;
   }
@@ -63,7 +63,7 @@
   }
 }
 
-@media (width >=992px) {
+@media (min-width: 992px) {
   .text-lg-left {
     text-align: left !important;
   }
@@ -77,7 +77,7 @@
   }
 }
 
-@media (width >=1200px) {
+@media (min-width: 1200px) {
   .text-xl-left {
     text-align: left !important;
   }
@@ -522,7 +522,7 @@ h3 {
   }
 }
 
-@media (width >=992px) {
+@media (min-width: 992px) {
   .navbar-light {
     border-radius: 60px;
   }


### PR DESCRIPTION
## Summary
- Use min-width for utility text alignment breakpoints
- Update navbar utilities to use min-width breakpoint

## Testing
- `npm run build`
- `npm run lint:scss` (fails: 430 problems)
- `npm test` (fails: 1 failing suite)

------
https://chatgpt.com/codex/tasks/task_e_68a4f102015c83259b59cef9eb162c8e