### PR TITLE
refactor: use css variables for colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ restaurante-frontend/
 - `npm run watch` – rebuilds on file changes
 - `npm run lint` / `npm run lint:scss` – code and style linting
 
+## Styling
+Color tokens are defined once in `src/assets/_base.scss` as CSS custom properties.
+Use them in components with the `var(--token)` syntax (e.g., `var(--primary)`).
+Sass variables remain only for build‑time values such as breakpoints.
+
 ## Testing
 - `npm test` – run Jest unit tests with coverage
 - `npm run e2e` – execute Angular end-to-end tests

--- a/src/app/modules/auth/login/login.component.scss
+++ b/src/app/modules/auth/login/login.component.scss
@@ -1,7 +1,7 @@
 @use "../../../../assets/styles.scss" as *;
 
 a.link {
-  color: $primary;
+  color: var(--primary);
   display: flex;
   justify-content: center;
   text-align: center;

--- a/src/app/modules/client/mis-pedidos/mis-pedidos.component.scss
+++ b/src/app/modules/client/mis-pedidos/mis-pedidos.component.scss
@@ -11,9 +11,9 @@
 }
 
 .pedido-card {
-  border: 1px solid $primary;
+  border: 1px solid var(--primary);
   border-radius: 16px;
-  background: $white;
+  background: var(--white);
   padding: 16px;
   display: grid;
   gap: 12px;
@@ -39,8 +39,8 @@
   display: grid;
   place-items: center;
   font-size: 22px;
-  border: 1px solid $secondary;
-  background: $white;
+  border: 1px solid var(--secondary);
+  background: var(--white);
 }
 
 .pedido-card__title {
@@ -51,7 +51,7 @@
 .pedido-card__id {
   margin: 0;
   font-weight: 700;
-  color: $secondary;
+  color: var(--secondary);
 }
 
 .pedido-card__tags {
@@ -65,32 +65,32 @@
   padding: 2px 10px;
   border-radius: 999px;
   font-size: .8rem;
-  background: $light;
-  border: 1px solid $quaternary;
-  color: $dark;
+  background: var(--light);
+  border: 1px solid var(--quaternary);
+  color: var(--dark);
 }
 
 .tag--ok {
-  color: $success;
-  border-color: $success;
+  color: var(--success);
+  border-color: var(--success);
   background: rgba(17, 228, 10, 0.06);
 }
 
 .tag--warn {
-  color: $warning;
-  border-color: $warning;
+  color: var(--warning);
+  border-color: var(--warning);
   background: rgba(255, 193, 7, .1);
 }
 
 .tag--danger {
-  color: $danger;
-  border-color: $danger;
+  color: var(--danger);
+  border-color: var(--danger);
   background: rgba(220, 53, 69, .08);
 }
 
 .tag--muted {
-  color: $primary;
-  border-color: $primary;
+  color: var(--primary);
+  border-color: var(--primary);
   background: rgba(0, 0, 0, .03);
 }
 
@@ -130,7 +130,7 @@
 
 .btn-link {
   font-weight: 600;
-  color: $primary;
+  color: var(--primary);
   text-decoration: none;
 
   &:hover {

--- a/src/app/modules/client/pedido/pedido.component.scss
+++ b/src/app/modules/client/pedido/pedido.component.scss
@@ -5,9 +5,9 @@
 }
 
 .pedido-card {
-  border: 1px solid $primary;
+  border: 1px solid var(--primary);
   border-radius: 16px;
-  background: $white;
+  background: var(--white);
   padding: 16px;
   display: grid;
   gap: 16px;
@@ -26,7 +26,7 @@
 .pedido-card__id {
   margin: 0;
   font-weight: 700;
-  color: $secondary;
+  color: var(--secondary);
 }
 
 .pedido-card__tags {
@@ -40,32 +40,32 @@
   padding: 2px 10px;
   border-radius: 999px;
   font-size: .8rem;
-  background: $light;
-  border: 1px solid $quaternary;
-  color: $dark;
+  background: var(--light);
+  border: 1px solid var(--quaternary);
+  color: var(--dark);
 }
 
 .tag--ok {
-  color: $success;
-  border-color: $success;
+  color: var(--success);
+  border-color: var(--success);
   background: rgba(17, 228, 10, 0.06);
 }
 
 .tag--warn {
-  color: $warning;
-  border-color: $warning;
+  color: var(--warning);
+  border-color: var(--warning);
   background: rgba(255, 193, 7, .1);
 }
 
 .tag--danger {
-  color: $danger;
-  border-color: $danger;
+  color: var(--danger);
+  border-color: var(--danger);
   background: rgba(220, 53, 69, .08);
 }
 
 .tag--muted {
-  color: $primary;
-  border-color: $primary;
+  color: var(--primary);
+  border-color: var(--primary);
   background: rgba(0, 0, 0, .03);
 }
 
@@ -99,7 +99,7 @@
 
 .back-link {
   font-weight: 600;
-  color: $primary;
+  color: var(--primary);
   text-decoration: none;
 
   &:hover {

--- a/src/app/modules/client/perfil/perfil.component.scss
+++ b/src/app/modules/client/perfil/perfil.component.scss
@@ -9,7 +9,7 @@
 
 // Card principal para que toda la vista quede "contenida"
 .perfil__container {
-  background: $white;
+  background: var(--white);
   border-radius: 16px;
   padding: 16px;
   display: grid;
@@ -32,8 +32,8 @@
   display: grid;
   place-items: center;
   font-size: 32px;
-  background: $white;
-  border: 1px solid $secondary;
+  background: var(--white);
+  border: 1px solid var(--secondary);
 }
 
 .perfil__titles {
@@ -45,7 +45,7 @@
   margin: 0;
   font-size: 1.6rem;
   font-weight: 700;
-  color: $secondary;
+  color: var(--secondary);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -54,14 +54,14 @@
 
 .perfil__subtitle {
   margin: 0;
-  color: $primary;
+  color: var(--primary);
   opacity: .9;
 }
 
 // Panel de datos del cliente
 .perfil__panel {
   background: rgba(0, 0, 0, .02);
-  border: 1px solid $primary;
+  border: 1px solid var(--primary);
   border-radius: 16px;
   padding: 12px 12px 12px 12px;
 }
@@ -78,19 +78,19 @@
   gap: 8px;
   padding: 8px 10px;
   background: rgba(0, 0, 0, .03);
-  border: 1px solid $quaternary;
+  border: 1px solid var(--quaternary);
   border-radius: 12px;
   font-size: .95rem;
 }
 
 .chip__label {
-  color: $dark;
+  color: var(--dark);
   opacity: .7;
   font-weight: 600;
 }
 
 .chip__value {
-  color: $dark;
+  color: var(--dark);
 }
 
 // Grid de accesos rápidos
@@ -107,8 +107,8 @@
   text-align: left;
   padding: 16px;
   border-radius: 16px;
-  border: 1px solid $primary;
-  background: $white;
+  border: 1px solid var(--primary);
+  background: var(--white);
   text-decoration: none;
   color: inherit;
   transition: transform .1s ease, box-shadow .1s ease;
@@ -126,19 +126,19 @@
 
 .card__title {
   font-weight: 700;
-  color: $secondary;
+  color: var(--secondary);
 }
 
 .card__text {
   margin: 0;
-  color: $dark;
+  color: var(--dark);
   opacity: .8;
   font-size: .95rem;
 }
 
 .card__cta {
   font-size: .9rem;
-  color: $primary;
+  color: var(--primary);
   font-weight: 600;
 }
 
@@ -152,12 +152,12 @@
   border-radius: 999px;
   padding: 2px 10px;
   font-size: .8rem;
-  background: $light;
+  background: var(--light);
 }
 
 .badge--ok {
-  color: $success;
-  border-color: $success;
+  color: var(--success);
+  border-color: var(--success);
   background: rgba(17, 228, 10, 0.06);
 }
 
@@ -170,7 +170,7 @@
   padding: 10px 12px;
   border-radius: 12px;
   background: rgba(0, 0, 0, .03);
-  border: 1px solid $quaternary;
+  border: 1px solid var(--quaternary);
 }
 
 .state__box--warn {

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.scss
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.scss
@@ -15,7 +15,7 @@
 }
 
 .search {
-    color: $primary;
+    color: var(--primary);
     font-size: 1.5rem;
     border: none;
     background: none;

--- a/src/app/modules/public/ubicacion-restaurante/ubicacion-restaurante.component.scss
+++ b/src/app/modules/public/ubicacion-restaurante/ubicacion-restaurante.component.scss
@@ -34,12 +34,12 @@
 }
 
 .info-card p {
-  color: $gray;
+  color: var(--gray);
   font-size: 1rem;
 }
 
 .info-card i {
-  color: $primary;
+  color: var(--primary);
   font-size: 1.8rem;
   margin-bottom: 10px;
 }

--- a/src/app/modules/public/ver-productos/ver-productos.component.scss
+++ b/src/app/modules/public/ver-productos/ver-productos.component.scss
@@ -43,7 +43,7 @@
 
         .producto-precio {
             font-size: 1rem;
-            color: $green;
+            color: var(--green);
             font-weight: bold;
         }
     }
@@ -99,7 +99,7 @@
 .form-group {
         label {
         margin-bottom: 4px;
-        color: $dark;
+        color: var(--dark);
     }
 
     input,
@@ -110,7 +110,7 @@
 
 .filtros-card {
     border: 1px solid var(--gray);
-    background-color: $white;
+    background-color: var(--white);
     border-radius: 20px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
@@ -132,9 +132,9 @@
 }
 
 .text-primary {
-    color: $primary !important;
+    color: var(--primary) !important;
 }
 
 .text-secondary {
-    color: $quaternary !important;
+    color: var(--quaternary) !important;
 }

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.scss
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.scss
@@ -29,12 +29,12 @@
 }
 
 .info-card p {
-  color: $gray;
+  color: var(--gray);
   font-size: 1rem;
 }
 
 .info-card i {
-  color: $primary;
+  color: var(--primary);
   font-size: 1.8rem;
   margin-bottom: 10px;
 }

--- a/src/assets/_base.scss
+++ b/src/assets/_base.scss
@@ -1,4 +1,5 @@
 @use 'variables' as *;
+@use "sass:color";
 
 :root {
   --blue: #{$blue};
@@ -24,6 +25,7 @@
   --danger: #{$danger};
   --light: #{$light};
   --dark: #{$dark};
+  --primary-dark: #{color.adjust($primary, $lightness: -15%)};
   --breakpoint-xs: 0;
   --breakpoint-sm: 576px;
   --breakpoint-md: 768px;

--- a/src/assets/_utilities.scss
+++ b/src/assets/_utilities.scss
@@ -1,6 +1,3 @@
-@use 'variables' as *;
-@use "sass:color";
-
 .text-monospace {
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;
 }
@@ -128,28 +125,28 @@
 }
 
 .text-white {
-  color: $white !important;
+  color: var(--white) !important;
 }
 
 .text-primary {
-  color: $secondary !important;
+  color: var(--secondary) !important;
 }
 
 a.text-primary {
   &:hover,
   &:focus {
-    color: $quaternary !important;
+    color: var(--quaternary) !important;
   }
 }
 
 .text-secondary {
-  color: $primary !important;
+  color: var(--primary) !important;
 }
 
 a.text-secondary {
   &:hover,
   &:focus {
-    color: $tertiary !important;
+    color: var(--tertiary) !important;
   }
 }
 
@@ -198,7 +195,7 @@ a.text-danger {
 }
 
 .text-light {
-  color: $white fff !important;
+  color: var(--white) !important;
 }
 
 a.text-light {
@@ -209,7 +206,7 @@ a.text-light {
 }
 
 .text-dark {
-  color: $dark !important;
+  color: var(--dark) !important;
 }
 
 a.text-dark {
@@ -224,7 +221,7 @@ a.text-dark {
 }
 
 .text-muted {
-  color: $gray !important;
+  color: var(--gray) !important;
 }
 
 .text-black-50 {
@@ -331,7 +328,7 @@ a.text-dark {
 
     td,
     th {
-      background-color: $white !important;
+      background-color: var(--white) !important;
     }
   }
 
@@ -372,7 +369,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  color: $dark;
+  color: var(--dark);
   font-weight: 500;
   line-height: 1.2;
   margin-bottom: 0.5rem;
@@ -468,7 +465,7 @@ h3 {
 
   &.btn-primary,
   &.btn-secondary {
-    color: $white fff;
+    color: var(--white);
   }
 }
 
@@ -494,7 +491,7 @@ h3 {
 }
 
 .nav-bar::before {
-  background: $tertiary;
+  background: var(--tertiary);
   content: "";
   height: 50%;
   left: 0;
@@ -504,7 +501,7 @@ h3 {
 }
 
 .navbar-light .navbar-nav .nav-link {
-  color: $dark;
+  color: var(--dark);
   font-size: 17px;
   font-weight: 500;
   outline: none;
@@ -512,7 +509,7 @@ h3 {
 
   &:hover,
   &.active {
-    color: $primary;
+    color: var(--primary);
   }
 }
 
@@ -549,7 +546,7 @@ h3 {
 
 .section-title {
   &::before {
-    background: $primary;
+    background: var(--primary);
     content: "";
     height: 5px;
     left: 0;
@@ -559,7 +556,7 @@ h3 {
   }
 
   &::after {
-    background: $primary;
+    background: var(--primary);
     content: "";
     height: 1px;
     left: 0;
@@ -577,7 +574,7 @@ h3 {
 }
 
 .btn-play {
-  background: $white fff;
+  background: var(--white);
   border: none;
   border-radius: 100%;
   box-sizing: content-box;
@@ -592,7 +589,7 @@ h3 {
 
   &::before {
     animation: pulse-border 1500ms ease-out infinite;
-    background: $white fff;
+    background: var(--white);
     border-radius: 100%;
     content: "";
     display: block;
@@ -606,7 +603,7 @@ h3 {
   }
 
   &::after {
-    background: $white fff;
+    background: var(--white);
     border-radius: 100%;
     content: "";
     display: block;
@@ -622,7 +619,7 @@ h3 {
 
   span {
     border-bottom: 15px solid transparent;
-    border-left: 25px solid $primary;
+    border-left: 25px solid var(--primary);
     border-top: 15px solid transparent;
     display: block;
     height: 0;
@@ -658,8 +655,8 @@ h3 {
   }
 
   .close {
-    background: $black;
-    color: $white fff;
+    background: var(--black);
+    color: var(--white);
     font-size: 30px;
     font-weight: normal;
     height: 30px;
@@ -686,9 +683,9 @@ h3 {
   .owl-prev,
   .owl-next {
     align-items: center;
-    background: $white fff;
+    background: var(--white);
     border-radius: 60px;
-    color: $primary;
+    color: var(--primary);
     display: flex;
     font-size: 30px;
     height: 60px;
@@ -709,7 +706,7 @@ h3 {
     z-index: 1;
 
     &::before {
-      background: $primary;
+      background: var(--primary);
       border-radius: 150px;
       content: "";
       inset: 15px 0 -15px;
@@ -735,21 +732,21 @@ h3 {
   }
 
   &:hover {
-    background: $secondary !important;
+    background: var(--secondary) !important;
 
     h5 {
-      color: $white fff !important;
+      color: var(--white) !important;
     }
 
     .btn {
-      background: $primary !important;
+      background: var(--primary) !important;
     }
   }
 }
 
 .portfolio-item {
   &::after {
-    border: 2px solid $white fff;
+    border: 2px solid var(--white);
     content: "";
     inset: 30px;
     position: absolute;
@@ -758,7 +755,7 @@ h3 {
 
   .portfolio-btn {
     align-items: center;
-    background: $white fff;
+    background: var(--white);
     display: flex;
     height: 0;
     justify-content: center;
@@ -784,7 +781,7 @@ h3 {
 .team-item {
   .team-img {
     align-items: center;
-    border: 15px solid $primary;
+    border: 15px solid var(--primary);
     border-radius: 200px;
     display: flex;
     height: 200px;
@@ -795,7 +792,7 @@ h3 {
     z-index: 1;
 
     &::after {
-      border: 2px solid $primary;
+      border: 2px solid var(--primary);
       border-radius: 200px;
       content: "";
       inset: 15px;
@@ -847,7 +844,7 @@ h3 {
   }
 
   .owl-dot {
-    background: $primary;
+    background: var(--primary);
     border-radius: 15px;
     display: inline-block;
     height: 15px;
@@ -856,7 +853,7 @@ h3 {
     width: 15px;
 
     &::after {
-      border: 2px solid $primary;
+      border: 2px solid var(--primary);
       border-radius: 20px;
       content: "";
       inset: -5px;
@@ -864,7 +861,7 @@ h3 {
     }
 
     &.active {
-      background: $secondary;
+      background: var(--secondary);
     }
   }
 }
@@ -896,22 +893,22 @@ label {
 }
 
 .badge-warning {
-  background-color: $warning;
+  background-color: var(--warning);
   color: black;
 }
 
 .badge-success {
-  background-color: $success;
+  background-color: var(--success);
   color: white;
 }
 
 .badge-secondary {
-  background-color: $cyan;
+  background-color: var(--cyan);
   color: white;
 }
 
 .badge-danger {
-  background-color: $danger;
+  background-color: var(--danger);
   color: white;
 }
 
@@ -974,13 +971,13 @@ label {
 }
 
 .search {
-  color: $primary;
+  color: var(--primary);
   margin-bottom: 10px;
 }
 
 .volver-container {
   align-items: center;
-  color: $primary;
+  color: var(--primary);
   cursor: pointer;
   display: inline-flex;
   font-size: 18px;
@@ -992,11 +989,11 @@ label {
     transform 0.2s ease;
   user-select: none;
 
-  &:hover {
-    color: color.adjust($primary, $lightness: -15%);
-    transform: translateX(-3px);
+    &:hover {
+      color: var(--primary-dark);
+      transform: translateX(-3px);
+    }
   }
-}
 
 .volver-icon {
   font-size: 22px;


### PR DESCRIPTION
## Summary
- add `--primary-dark` variable and rely on CSS custom properties for color tokens
- migrate component and utility styles to `var(--token)` syntax
- document styling convention in README

## Testing
- `npm run lint:scss` *(fails: numerous stylelint errors)*
- `npm test` *(fails: MisPedidosComponent tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f109b55483258c5b4abe61003924