### PR TITLE
Fix string delivery selection handling in cart

### DIFF
--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -167,6 +167,19 @@ describe('CarritoComponent', () => {
     expect(finalizeSpy).toHaveBeenCalledWith(3, 9);
   });
 
+  it('should handle string "true" for delivery selection', async () => {
+    await setup();
+    modalServiceMock.getModalData.mockReturnValue({ selects: [{ selected: 4 }, { selected: 'true' }] });
+    userServiceMock.getUserId.mockReturnValue(88);
+    clienteServiceMock.getClienteId.mockReturnValue(of({ data: { direccion: 'dir2', telefono: 'tel2', observaciones: '' } }));
+    domicilioServiceMock.createDomicilio.mockReturnValue(of({ data: { domicilioId: 5 } }));
+    const finalizeSpy = jest.spyOn(component as any, 'finalizeOrder').mockImplementation(() => {});
+    await (component as any).onCheckoutConfirm();
+    expect(clienteServiceMock.getClienteId).toHaveBeenCalledWith(88);
+    expect(domicilioServiceMock.createDomicilio).toHaveBeenCalled();
+    expect(finalizeSpy).toHaveBeenCalledWith(4, 5);
+  });
+
   it('should handle error when getting client data fails', async () => {
     await setup();
     modalServiceMock.getModalData.mockReturnValue({ selects: [{ selected: 1 }, { selected: true }] });

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -106,7 +106,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
     const { selects } = this.modalService.getModalData();
     const [methodSelect, deliverySelect] = selects!;
     const methodId = methodSelect.selected as number;
-    const needsDelivery = deliverySelect.selected as boolean;
+    const needsDelivery = deliverySelect.selected === true || deliverySelect.selected === 'true';
 
     this.modalService.closeModal();
 


### PR DESCRIPTION
## Summary
- handle "true" string in delivery dropdown when checking out
- test delivery flow when dropdown returns "true" string

## Testing
- `npm test` *(fails: MisPedidosComponent specs)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fda8cd48832586f5026963b70d4a