### PR TITLE
fix: send product details as array

### DIFF
--- a/src/app/core/services/producto-pedido.service.spec.ts
+++ b/src/app/core/services/producto-pedido.service.spec.ts
@@ -43,8 +43,9 @@ describe('ProductoPedidoService', () => {
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
       PK_ID_PEDIDO: 1,
-      DETALLES_PRODUCTOS: JSON.stringify(payload.DETALLES_PRODUCTOS)
+      DETALLES_PRODUCTOS: payload.DETALLES_PRODUCTOS
     });
+    expect(Array.isArray(req.request.body.DETALLES_PRODUCTOS)).toBe(true);
     req.flush(mock);
   });
 

--- a/src/app/core/services/producto-pedido.service.ts
+++ b/src/app/core/services/producto-pedido.service.ts
@@ -27,7 +27,7 @@ export class ProductoPedidoService {
   create(payload: CrearProductoPedido): Observable<ApiResponse<any>> {
     return this.http.post<ApiResponse<any>>(this.baseUrl, {
       PK_ID_PEDIDO: payload.PK_ID_PEDIDO,
-      DETALLES_PRODUCTOS: JSON.stringify(payload.DETALLES_PRODUCTOS)
+      DETALLES_PRODUCTOS: payload.DETALLES_PRODUCTOS
     }).pipe(
       catchError(this.handleError.handleError)
     );


### PR DESCRIPTION
## Summary
- send product details as a JSON array when creating product orders
- update unit tests to expect array payload

## Testing
- `npm test` *(fails: CarritoComponent should handle string "true" for delivery selection; MisPedidosComponent ngOnInit should sort and enrich pedidos; MisPedidosComponent mergeDetalles should merge products and calculate totals; MisPedidosComponent mergeDetalles should handle invalid JSON)*
- `npx jest src/app/core/services/producto-pedido.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a66dda669083258e41396c347195c9