### PR TITLE
Standardize delivery flag in pedido contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Sass variables remain only for build‑time values such as breakpoints.
 4. Mark the PR as **Ready for review** once complete.
 
 ## API Documentation
-Placeholder
+See [docs/pedidos-contract.md](docs/pedidos-contract.md) for the current contract of the pedidos endpoint, including the `delivery` boolean field.
 
 ## Additional Documentation
 Placeholder

--- a/docs/pedidos-contract.md
+++ b/docs/pedidos-contract.md
@@ -1,0 +1,28 @@
+# Pedidos API Contract
+
+## POST /pedidos
+Request body:
+
+```json
+{
+  "delivery": true
+}
+```
+
+- `delivery` *(boolean)*: `true` when the order should be delivered to a domicile, `false` for on-site consumption.
+
+## GET /pedidos/detalles
+The response includes the `delivery` field in camelCase:
+
+```json
+{
+  "data": {
+    "delivery": false,
+    "METODO_PAGO": "Nequi",
+    "PRODUCTOS": "[]",
+    ...
+  }
+}
+```
+
+Both frontend and backend must use the `delivery` property name exactly as shown to keep the contract consistent.

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -106,7 +106,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
     const { selects } = this.modalService.getModalData();
     const [methodSelect, deliverySelect] = selects!;
     const methodId = methodSelect.selected as number;
-    const needsDelivery = deliverySelect.selected === true;
+    const needsDelivery = deliverySelect.selected === true || deliverySelect.selected === 'true';
 
     this.modalService.closeModal();
 

--- a/src/app/modules/client/mis-pedidos/mis-pedidos.component.spec.ts
+++ b/src/app/modules/client/mis-pedidos/mis-pedidos.component.spec.ts
@@ -71,7 +71,7 @@ describe('MisPedidosComponent', () => {
 
     pedidoService.getPedidoDetalles.mockImplementation((id: number) => {
       if (id === 1) {
-        return of({ data: { METODO_PAGO: 'CARD', PRODUCTOS: '[]' } });
+        return of({ data: { metodoPago: 'CARD', productos: '[]' } });
       }
       return throwError(() => new Error('fail'));
     });
@@ -128,8 +128,8 @@ describe('MisPedidosComponent', () => {
 
     it('should merge products and calculate totals', () => {
       const det = {
-        METODO_PAGO: 'EFECTIVO',
-        PRODUCTOS: JSON.stringify([
+        metodoPago: 'EFECTIVO',
+        productos: JSON.stringify([
           { SUBTOTAL: 10 },
           { PRECIO_UNITARIO: 2, CANTIDAD: 3 },
           { PRECIO_UNITARIO: 5, CANTIDAD: 'bad' },
@@ -146,7 +146,7 @@ describe('MisPedidosComponent', () => {
     });
 
     it('should handle missing product string', () => {
-      const det = { METODO_PAGO: 'CARD' } as any;
+      const det = { metodoPago: 'CARD' } as any;
       const res = (component as any).mergeDetalles(basePedido, det);
       expect(res.productos).toEqual([]);
       expect(res.total).toBe(0);
@@ -154,7 +154,7 @@ describe('MisPedidosComponent', () => {
     });
 
     it('should handle non array product string', () => {
-      const det = { METODO_PAGO: 'CARD', PRODUCTOS: JSON.stringify({ foo: 1 }) };
+      const det = { metodoPago: 'CARD', productos: JSON.stringify({ foo: 1 }) };
       const res = (component as any).mergeDetalles(basePedido, det);
       expect(res.productos).toEqual([]);
       expect(res.total).toBe(0);
@@ -162,7 +162,7 @@ describe('MisPedidosComponent', () => {
     });
 
     it('should handle invalid JSON', () => {
-      const det = { PRODUCTOS: 'invalid' } as any;
+      const det = { productos: 'invalid' } as any;
       const res = (component as any).mergeDetalles(basePedido, det);
       expect(res.metodoPago).toBeUndefined();
       expect(res.productos).toBeUndefined();

--- a/src/app/modules/client/pedido/pedido.component.spec.ts
+++ b/src/app/modules/client/pedido/pedido.component.spec.ts
@@ -30,7 +30,19 @@ describe('PedidoComponent', () => {
   });
 
   it('should load pedido on init', () => {
-    pedidoService.getPedidoDetalles.mockReturnValue(of({ data: { PK_ID_PEDIDO: 5, PRODUCTOS: '[]', METODO_PAGO: 'Nequi', FECHA: '01-01-2024', HORA: '0000-01-01 10:00:00 +0000 UTC', DELIVERY: true, ESTADO_PEDIDO: 'TERMINADO' } }));
+    pedidoService.getPedidoDetalles.mockReturnValue(
+      of({
+        data: {
+          PK_ID_PEDIDO: 5,
+          PRODUCTOS: '[]',
+          METODO_PAGO: 'Nequi',
+          FECHA: '01-01-2024',
+          HORA: '0000-01-01 10:00:00 +0000 UTC',
+          delivery: true,
+          ESTADO_PEDIDO: 'TERMINADO'
+        }
+      })
+    );
     component.ngOnInit();
     expect(pedidoService.getPedidoDetalles).toHaveBeenCalledWith(5);
     expect(component.loading).toBe(false);

--- a/src/app/shared/mocks/pedido.mock.ts
+++ b/src/app/shared/mocks/pedido.mock.ts
@@ -63,7 +63,7 @@ export const mockPedidoDetalle: ApiResponse<PedidoDetalle> = {
         PK_ID_PEDIDO: 0,
         FECHA: "",
         HORA: "",
-        DELIVERY: false,
+        delivery: false,
         ESTADO_PEDIDO: "",
         METODO_PAGO: "Nequi",
         PRODUCTOS: "[{\"NOMBRE\": \"Coca Cola 500ml\", \"CANTIDAD\": 1, \"SUBTOTAL\": 2000, \"PK_ID_PRODUCTO\": 1, \"PRECIO_UNITARIO\": 2000}]"

--- a/src/app/shared/models/pedido.model.ts
+++ b/src/app/shared/models/pedido.model.ts
@@ -16,7 +16,7 @@ export interface PedidoDetalle {
     PK_ID_PEDIDO?: number;
     FECHA: string;
     HORA: string;
-    DELIVERY: boolean;
+    delivery: boolean;
     ESTADO_PEDIDO: string;
     METODO_PAGO: string;
     PRODUCTOS: string;


### PR DESCRIPTION
## Summary
- Document pedidos API contract and delivery flag
- Use camelCase `delivery` in pedido models, mocks and tests
- Handle string `"true"` in checkout and use camelCase field when creating pedidos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66ddd6d008325afdf584e32ba5a9f