### PR TITLE
Include payment info in order creation

### DIFF
--- a/src/app/core/services/pedido.service.spec.ts
+++ b/src/app/core/services/pedido.service.spec.ts
@@ -71,7 +71,7 @@ describe('PedidoService', () => {
   });
 
   it('assigns domicilio', () => {
-    const mock = { code: 200, message: 'ok' };
+    const mock = { code: 200, message: 'ok', data: { delivery: true, estadoPedido: 'EN CURSO' } };
     service.assignDomicilio(1, 3).subscribe(res => expect(res).toEqual(mock));
     const req = http.expectOne(`${baseUrl}/asignar-domicilio?pedido_id=1&domicilio_id=3`);
     expect(req.request.method).toBe('POST');

--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -243,9 +243,14 @@ describe('CarritoComponent', () => {
     pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 99 } }));
     productoPedidoServiceMock.create.mockReturnValue(of({}));
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
-    pedidoServiceMock.assignPago.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
     await (component as any).finalizeOrder(1, null);
+    expect(pedidoServiceMock.createPedido).toHaveBeenCalledWith({
+      delivery: false,
+      pagoId: 1,
+      estadoPedido: 'PENDIENTE'
+    });
+    expect(pedidoServiceMock.assignPago).not.toHaveBeenCalled();
     expect(pedidoServiceMock.assignDomicilio).not.toHaveBeenCalled();
     expect(cartServiceMock.clearCart).toHaveBeenCalled();
     expect(routerMock.navigate).toHaveBeenCalledWith(['/cliente/mis-pedidos']);
@@ -258,9 +263,14 @@ describe('CarritoComponent', () => {
     pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 50 } }));
     productoPedidoServiceMock.create.mockReturnValue(of({}));
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
-    pedidoServiceMock.assignPago.mockReturnValue(of({}));
-    pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
+    pedidoServiceMock.assignDomicilio.mockReturnValue(of({ data: { delivery: true, estadoPedido: 'EN CURSO' } }));
     await (component as any).finalizeOrder(2, 7);
+    expect(pedidoServiceMock.createPedido).toHaveBeenCalledWith({
+      delivery: true,
+      pagoId: 2,
+      estadoPedido: 'PENDIENTE'
+    });
+    expect(pedidoServiceMock.assignPago).not.toHaveBeenCalled();
     expect(pedidoServiceMock.assignDomicilio).toHaveBeenCalledWith(50, 7);
   });
 


### PR DESCRIPTION
## Summary
- Attach payment and status when creating a pedido
- Skip pago assignment until payment confirmation
- Check domicilio assignment returns expected state and adjust tests

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*


------
https://chatgpt.com/codex/tasks/task_e_68a8e61c9a9c83259c496ab9c0103436