### PR TITLE
fix: merge delivery data in pedidos

### DIFF
--- a/src/app/modules/client/mis-pedidos/mis-pedidos.component.spec.ts
+++ b/src/app/modules/client/mis-pedidos/mis-pedidos.component.spec.ts
@@ -169,6 +169,15 @@ describe('MisPedidosComponent', () => {
       expect(res.total).toBeUndefined();
       expect(res.items).toBeUndefined();
     });
+
+    it('should merge delivery flag with fallback to pedido', () => {
+      const base = { ...basePedido, delivery: false };
+      const res1 = (component as any).mergeDetalles(base, { delivery: true });
+      expect(res1.delivery).toBe(true);
+
+      const res2 = (component as any).mergeDetalles(base, {} as any);
+      expect(res2.delivery).toBe(false);
+    });
   });
 
   it('toComparableDate should convert to UTC date', () => {

--- a/src/app/modules/client/mis-pedidos/mis-pedidos.component.ts
+++ b/src/app/modules/client/mis-pedidos/mis-pedidos.component.ts
@@ -117,6 +117,7 @@ export class MisPedidosComponent implements OnInit, OnDestroy {
 
     return {
       ...p,
+      delivery: det.delivery ?? p.delivery,
       metodoPago: det.metodoPago || undefined,
       productos,
       total: total !== undefined ? total : undefined,


### PR DESCRIPTION
## Summary
- ensure mergeDetalles keeps delivery flag from API
- test delivery merge behaviour in MisPedidosComponent

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*


------
https://chatgpt.com/codex/tasks/task_e_68a906b0820883258520a3afe9cd4618