### PR TITLE
feat: send domicilio when creating order

### DIFF
--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -240,13 +240,14 @@ describe('CarritoComponent', () => {
     await setup();
     component.carrito = [{ productoId: 1, nombre: 'P1', cantidad: 2, precio: 10 }];
     userServiceMock.getUserId.mockReturnValue(5);
-    pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 99 } }));
+    pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 99, delivery: false } }));
     productoPedidoServiceMock.create.mockReturnValue(of({}));
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({}));
     await (component as any).finalizeOrder(1, null);
     expect(pedidoServiceMock.createPedido).toHaveBeenCalledWith({
       delivery: false,
+      domicilioId: null,
       pagoId: 1,
       estadoPedido: 'PENDIENTE'
     });
@@ -260,13 +261,14 @@ describe('CarritoComponent', () => {
     await setup();
     component.carrito = [{ productoId: 1, nombre: 'P1', cantidad: 1, precio: 10 }];
     userServiceMock.getUserId.mockReturnValue(5);
-    pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 50 } }));
+    pedidoServiceMock.createPedido.mockReturnValue(of({ data: { pedidoId: 50, delivery: true } }));
     productoPedidoServiceMock.create.mockReturnValue(of({}));
     pedidoClienteServiceMock.create.mockReturnValue(of({}));
     pedidoServiceMock.assignDomicilio.mockReturnValue(of({ data: { delivery: true, estadoPedido: 'EN CURSO' } }));
     await (component as any).finalizeOrder(2, 7);
     expect(pedidoServiceMock.createPedido).toHaveBeenCalledWith({
       delivery: true,
+      domicilioId: 7,
       pagoId: 2,
       estadoPedido: 'PENDIENTE'
     });

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -177,12 +177,17 @@ export class CarritoComponent implements OnInit, OnDestroy {
         this.pedidoService
           .createPedido({
             delivery: domicilioId !== null,
+            domicilioId,
             pagoId: methodId,
             estadoPedido: 'PENDIENTE'
           })
           .pipe(takeUntil(this.destroy$))
       );
-      const pedidoId = pedidoRes.data.pedidoId!;
+      const pedidoData = pedidoRes.data;
+      const pedidoId = pedidoData.pedidoId!;
+      if (domicilioId !== null && pedidoData.delivery !== true) {
+        console.warn('El backend no persiste delivery como true', pedidoData);
+      }
 
       const detalles = this.carrito.map(p => ({
         PK_ID_PRODUCTO: p.productoId!,


### PR DESCRIPTION
## Summary
- include domicilioId in order creation
- warn when backend doesn't persist delivery
- update carrito unit tests for domicilio payload

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode' from 'src/app/core/services/user.service.ts')*

------
https://chatgpt.com/codex/tasks/task_e_68a90dfa26cc83259622bc59c7381f56