### PR TITLE
feat: handle auth guard session expiry

### DIFF
--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -10,9 +10,15 @@ export class AuthGuard implements CanActivate {
   constructor(private userService: UserService, private router: Router, private toastr: ToastrService) { }
 
   canActivate(): boolean {
-    if (this.userService.isTokenExpired()) {
+    if (!this.userService.isLoggedIn()) {
       this.router.navigate(['/login']);
+      return false;
+    }
+
+    if (this.userService.isTokenExpired()) {
+      this.toastr.clear();
       this.toastr.error('La sesión ha expirado, por favor inicia sesión nuevamente', 'Sesión expirada');
+      this.router.navigate(['/login']);
       return false;
     }
 


### PR DESCRIPTION
## Summary
- Check login and token validity before route activation
- Add comprehensive auth guard tests for login and token expiration flows

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode' from 'src/app/core/services/user.service.ts')*


------
https://chatgpt.com/codex/tasks/task_e_68ababbe29488325b6e00c5f62b8c1bd