### PR TITLE
Handle missing auth token in isTokenExpired

### DIFF
--- a/src/app/core/services/user.service.spec.ts
+++ b/src/app/core/services/user.service.spec.ts
@@ -162,8 +162,15 @@ describe('UserService', () => {
     expect(mockLoggingService.log).toHaveBeenCalledWith(LogLevel.ERROR, 'Error al decodificar el token', expect.any(Error));
   });
 
-  it('should return true if decodeToken returns null for token expiry', () => {
-    jest.spyOn(service, 'decodeToken').mockReturnValue(null);
+  it('should return false if token does not exist for token expiry', () => {
+    localStorage.removeItem('auth_token');
+    const result = service.isTokenExpired();
+    expect(result).toBe(false);
+  });
+
+  it('should return true if decodeTokenSafely returns null for token expiry', () => {
+    localStorage.setItem('auth_token', 'testToken');
+    jest.spyOn<any>(service, 'decodeTokenSafely').mockReturnValue(null);
     const result = service.isTokenExpired();
     expect(result).toBe(true);
   });

--- a/src/app/core/services/user.service.ts
+++ b/src/app/core/services/user.service.ts
@@ -78,7 +78,11 @@ export class UserService {
 
   isTokenExpired(): boolean {
     const token = this.getToken();
-    const decoded: DecodedToken | null = token ? this.decodeTokenSafely(token) : null;
+    if (!token) {
+      return false;
+    }
+
+    const decoded: DecodedToken | null = this.decodeTokenSafely(token);
     if (!decoded || typeof decoded.exp !== 'number') return true;
 
     const currentTime = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Summary
- Return `false` from `isTokenExpired` when there is no token
- Add tests covering missing token and decode failures

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*

------
https://chatgpt.com/codex/tasks/task_e_68ababbfe908832581a8dbcada348297