### PR TITLE
feat: add optional input field to modal component

### DIFF
--- a/src/app/shared/components/modal/modal.component.html
+++ b/src/app/shared/components/modal/modal.component.html
@@ -37,6 +37,11 @@
                     </option>
                 </select>
             </div>
+
+            <div class="form-group mt-3" *ngIf="modalData.input">
+                <label>{{ modalData.input.label }}</label>
+                <textarea class="form-control" [(ngModel)]="modalData.input.value"></textarea>
+            </div>
         </div>
 
         <div class="modal-buttons" *ngIf="modalData.buttons">

--- a/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/app/shared/components/modal/modal.component.spec.ts
@@ -52,4 +52,22 @@ describe('ModalComponent', () => {
     component.close();
     expect(modalServiceSpy.closeModal).toHaveBeenCalled();
   });
+
+  it('should render and bind input field when modalData has input', async () => {
+    const inputData = { input: { label: 'Reason', value: 'Initial' } };
+    modalDataSubject.next(inputData);
+    isOpenSubject.next(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const textarea: HTMLTextAreaElement = fixture.nativeElement.querySelector('textarea');
+    expect(textarea).toBeTruthy();
+    expect(textarea.value).toBe('Initial');
+
+    textarea.value = 'Updated';
+    textarea.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component.modalData.input?.value).toBe('Updated');
+  });
 });

--- a/src/app/shared/models/modal.model.ts
+++ b/src/app/shared/models/modal.model.ts
@@ -30,5 +30,6 @@ export interface ModalData {
     details?: ModalDetails;
     select?: ModalSelect;
     selects?: ModalSelect[];
+    input?: { label: string; value: string };
     buttons?: ModalButton[];
 }


### PR DESCRIPTION
## Summary
- extend modal model with optional input field
- show bound textarea for modal input values
- test modal input rendering and binding

## Testing
- `npm test` (fails: Cannot find module 'jwt-decode')
- `npx jest src/app/shared/components/modal/modal.component.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b0d4bc53a4832587d6e10946ec9a51