### PR TITLE
feat: capture observations during checkout

### DIFF
--- a/src/app/shared/components/modal/modal.component.html
+++ b/src/app/shared/components/modal/modal.component.html
@@ -18,6 +18,11 @@
                 <p><strong>Descripción:</strong> {{ modalData.details.descripcion || 'Sin descripción' }}</p>
             </div>
 
+            <div class="form-group mt-3" *ngIf="modalData.input">
+                <label>{{ modalData.input.label }}</label>
+                <input type="text" class="form-control" [(ngModel)]="modalData.input.value" />
+            </div>
+
             <ng-container *ngIf="modalData.selects">
                 <div *ngFor="let sel of modalData.selects" class="form-group mt-3">
                     <label>{{ sel.label }}</label>

--- a/src/app/shared/models/modal.model.ts
+++ b/src/app/shared/models/modal.model.ts
@@ -15,6 +15,11 @@ export interface ModalSelect {
     selected: any;
 }
 
+export interface ModalInput {
+    label: string;
+    value: string;
+}
+
 export interface ModalDetails {
     precio: number;
     calorias?: number;
@@ -30,5 +35,6 @@ export interface ModalData {
     details?: ModalDetails;
     select?: ModalSelect;
     selects?: ModalSelect[];
+    input?: ModalInput;
     buttons?: ModalButton[];
 }


### PR DESCRIPTION
## Summary
- add optional input to modal to collect checkout observations
- store selected payment label and note when confirming an order
- include method and note in domicilio creation
- update tests for new checkout flow

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*

------
https://chatgpt.com/codex/tasks/task_e_68b0d4bea19483259e62edcb19aab924