### PR TITLE
feat: improve header responsiveness

### DIFF
--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -13,7 +13,7 @@
       position: absolute;
       transform: translateX(-50%) rotate(-5deg);
       transition: transform 0.3s ease;
-      width: 200px;
+      width: clamp(120px, 20vw, 200px);
     }
 
     .logo-text {
@@ -29,7 +29,9 @@
 
 @media (width <=991px) {
   .logo-container {
-    display: none !important;
+    .logo-img {
+      width: clamp(100px, 25vw, 150px);
+    }
   }
 }
 
@@ -40,21 +42,30 @@
 }
 
 .menu-left {
-  margin-right: 20px;
+  margin-right: 1.25rem;
 }
 
 .menu-right {
-  margin-left: 20px;
+  margin-left: 1.25rem;
+}
+
+@media (width <=576px) {
+  .menu-left {
+    margin-right: 0.5rem;
+  }
+
+  .menu-right {
+    margin-left: 0.5rem;
+  }
 }
 
 .menu-right {
   .nav-link {
     &.position-relative {
-
       // ya lo agregamos en el template
       .cart-badge {
-        position: absolute;
         font-size: 0.5rem;
+        position: absolute;
       }
     }
   }


### PR DESCRIPTION
## Summary
- make header logo size responsive with clamp
- keep logo visible on smaller screens instead of hiding
- switch menu spacing to rem units with mobile adjustments

## Testing
- `npm run lint:scss` *(fails: Unknown rule indentation and 430 errors across assets)*
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm test` *(fails: Cannot find module 'jwt-decode')*

------
https://chatgpt.com/codex/tasks/task_e_68b0ef6f62f88325a2556169929164d4