### PR TITLE
fix: responsive styles for carrito component

### DIFF
--- a/src/app/modules/client/carrito/carrito.component.scss
+++ b/src/app/modules/client/carrito/carrito.component.scss
@@ -2,11 +2,12 @@
 
 // Card más compacta
 .carrito-card {
-    max-width: 500px; // reduce el ancho máximo
     border-radius: 20px;
-    max-height: 500px;
+    max-height: 90vh;
+    max-width: 90vw; // reduce el ancho máximo
     overflow: hidden;
     transition: transform 0.2s ease;
+    width: 100%;
 
     &:hover {
         transform: translateY(-3px);
@@ -14,18 +15,20 @@
 }
 
 .card-img-top {
-    height: 150px;
+    aspect-ratio: 4 / 3;
+    height: auto;
     object-fit: cover;
+    width: 100%;
 }
 
 .btn-icon {
-    border: none;
     background: none;
-    padding: 0.25rem 0.5rem;
-    font-size: 1.25rem;
-    line-height: 1;
+    border: none;
     color: var(--quaternary);
     cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+    padding: 0.25rem 0.5rem;
     transition: color 0.2s ease;
 
     &_plus {
@@ -42,7 +45,28 @@
     font-weight: bold;
 
     small {
-        font-size: 0.8rem;
         color: var(--gray-dark);
+        font-size: 0.8rem;
+    }
+}
+
+@media (max-width: 400px) {
+    .carrito-card {
+        border-radius: 10px;
+        max-height: none;
+        max-width: 100vw;
+    }
+
+    .btn-icon {
+        font-size: 1rem;
+        padding: 0.2rem 0.4rem;
+    }
+
+    .resumen {
+        align-items: center;
+        flex-direction: column;
+        gap: 0.5rem;
+        justify-content: center;
+        text-align: center;
     }
 }


### PR DESCRIPTION
## Summary
- use relative widths/heights for carrito cards and images
- add mobile media query for tighter layout

## Testing
- `npx stylelint src/app/modules/client/carrito/carrito.component.scss` *(fails: Unknown rule indentation)*
- `npm test` *(fails: Cannot find module 'jwt-decode')*


------
https://chatgpt.com/codex/tasks/task_e_68b0ef758dfc8325b9984a42acc69b08