### PR TITLE
feat: responsive not-found text

### DIFF
--- a/src/app/modules/public/page-not-found/page-not-found.component.scss
+++ b/src/app/modules/public/page-not-found/page-not-found.component.scss
@@ -36,12 +36,12 @@ svg {
 
 h1 {
   color: var(--primary);
-  font-size: 8rem;
+  font-size: clamp(3rem, 10vw, 8rem);
 }
 
 p {
   color: var(--gray);
-  font-size: 1.5rem;
+  font-size: clamp(1rem, 4vw, 1.5rem);
 }
 
 a {


### PR DESCRIPTION
## Summary
- make not found heading and paragraph font sizes responsive via `clamp`

## Testing
- `npm run lint:scss` *(fails: 430 problems)*
- `npm test` *(fails: 27 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ef7a97108325be1a4d6bbb792c17