### PR TITLE
refactor: use breakpoint variables in media queries

### DIFF
--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -27,13 +27,13 @@
   }
 }
 
-@media (width <=991px) {
+@media (max-width: $breakpoint-lg) {
   .logo-container {
     display: none !important;
   }
 }
 
-@media (width <= $breakpoint-xl) {
+@media (max-width: $breakpoint-xl) {
   .logo-container {
     flex-grow: 0.75 !important;
   }

--- a/src/assets/_utilities.scss
+++ b/src/assets/_utilities.scss
@@ -1,3 +1,5 @@
+@use 'variables' as *;
+
 .text-monospace {
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;
 }
@@ -32,7 +34,7 @@
   text-align: center !important;
 }
 
-@media (min-width: 576px) {
+@media (min-width: $breakpoint-sm) {
   .text-sm-left {
     text-align: left !important;
   }
@@ -46,7 +48,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: $breakpoint-md) {
   .text-md-left {
     text-align: left !important;
   }
@@ -60,7 +62,7 @@
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: $breakpoint-lg) {
   .text-lg-left {
     text-align: left !important;
   }
@@ -74,7 +76,7 @@
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: $breakpoint-xl) {
   .text-xl-left {
     text-align: left !important;
   }
@@ -425,7 +427,7 @@ h6,
   font-size: 1rem;
 }
 
-@media (width <=1200px) {
+@media (max-width: $breakpoint-xl) {
   h1,
   .h1 {
     font-size: calc(1.375rem + 1.5vw);
@@ -513,13 +515,13 @@ h3 {
   }
 }
 
-@media (width <=991.98px) {
+@media (max-width: $breakpoint-lg) {
   .navbar-light .navbar-nav .nav-link {
     padding: 10px 0;
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: $breakpoint-lg) {
   .navbar-light {
     border-radius: 60px;
   }
@@ -872,7 +874,7 @@ h3 {
   padding: 0;
 }
 
-@media (width <=575.98px) {
+@media (max-width: $breakpoint-sm) {
   .footer .border-right {
     border-right: none !important;
   }
@@ -946,7 +948,7 @@ label {
   }
 }
 
-@media (width <=925px) {
+@media (max-width: $breakpoint-lg) {
   .table-container {
     display: block;
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- replace hardcoded media queries with breakpoint variables
- import shared breakpoint variables for responsive header

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*
- `npm run lint:scss` *(fails: 430 errors)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ef7c126483259de1bb255a83eda1