### PR TITLE
chore: rename depcheck script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ restaurante-frontend/
 - `npm run start` – start local dev server on http://localhost:4200
 - `npm run watch` – rebuilds on file changes
 - `npm run lint` / `npm run lint:scss` – code and style linting
+- `npm run deps:unused` – detect unused dependencies
 
 ## Styling
 Color tokens are defined once in `src/assets/_base.scss` as CSS custom properties.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "limpieza": "npx rimraf node_modules package-lock.json .angular/cache && npm install --prefer-online",
-    "unnecesary": "npx depcheck",
+    "deps:unused": "npx depcheck",
     "updates": "npm-check-updates -u && npm install",
     "lint:scss": "stylelint src/**/*.scss --fix",
     "serve:ssr:restaurante-frontend": "node dist/restaurante-frontend/server/server.mjs"


### PR DESCRIPTION
## Summary
- rename depcheck npm script to `deps:unused`
- document unused dependency check command in README

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npm run lint:scss` *(fails: 430 stylelint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5ef24e083258a493677f8e22d7c