### PR TITLE
feat: add basic Cypress e2e configuration

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -113,6 +113,12 @@
             ],
             "scripts": []
           }
+        },
+        "e2e": {
+          "builder": "@angular-devkit/architect:run-commands",
+          "options": {
+            "command": "cypress run"
+          }
         }
       }
     }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4200'
+  }
+});

--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -1,0 +1,5 @@
+describe('App', () => {
+  it('should visit the home page', () => {
+    cy.visit('/');
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,4 @@
+// This file is processed automatically before running tests.
+// Add custom commands or setup here.
+
+export {};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "jest --coverage",
     "lint": "ng lint",
-    "e2e": "ng e2e",
+    "e2e": "ng run restaurante-frontend:e2e",
     "limpieza": "npx rimraf node_modules package-lock.json .angular/cache && npm install --prefer-online",
     "unnecesary": "npx depcheck",
     "updates": "npm-check-updates -u && npm install",


### PR DESCRIPTION
## Summary
- add a minimal Cypress setup and sample spec
- wire up an `e2e` target using run-commands
- update `npm run e2e` to invoke the new target

## Testing
- `npm test` *(fails: Cannot find module 'jwt-decode')*
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5ee59d8832585f79fe74afd8177