### PR TITLE
refactor: align services with API contract

### DIFF
--- a/src/__mocks__/jwt-decode.ts
+++ b/src/__mocks__/jwt-decode.ts
@@ -1,0 +1,3 @@
+export function jwtDecode(): any {
+  return {};
+}

--- a/src/app/core/services/domicilio.service.spec.ts
+++ b/src/app/core/services/domicilio.service.spec.ts
@@ -2,7 +2,10 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
-import { Domicilio } from '../../shared/models/domicilio.model';
+import {
+  Domicilio,
+  DomicilioRequest,
+} from '../../shared/models/domicilio.model';
 import {
   mockDomicilioBody,
   mockDomicilioRespone,
@@ -129,7 +132,10 @@ describe('DomicilioService', () => {
   describe('updateDomicilio', () => {
     it('should PUT updated domicilio', () => {
       const id = 1;
-      const updatedData: Partial<Domicilio> = { entregado: true };
+      const updatedData: DomicilioRequest = {
+        ...mockDomicilioBody,
+        direccion: 'Nueva Direccion',
+      };
       const mockResponse = mockDomicilioRespone;
 
       service.updateDomicilio(id, updatedData).subscribe((response) => {
@@ -144,7 +150,7 @@ describe('DomicilioService', () => {
 
     it('should handle error when PUT domicilio', () => {
       const id = 1;
-      const updatedData: Partial<Domicilio> = { entregado: true };
+      const updatedData: Partial<DomicilioRequest> = { direccion: 'Dir' };
       service.updateDomicilio(id, updatedData).subscribe({
         error: (error) => {
           expect(error).toBeTruthy();

--- a/src/app/core/services/domicilio.service.ts
+++ b/src/app/core/services/domicilio.service.ts
@@ -3,7 +3,11 @@ import { Injectable } from '@angular/core';
 import { Observable, catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
-import { Domicilio, DomicilioDetalle } from '../../shared/models/domicilio.model';
+import {
+  Domicilio,
+  DomicilioDetalle,
+  DomicilioRequest,
+} from '../../shared/models/domicilio.model';
 import { HandleErrorService } from './handle-error.service';
 
 @Injectable({
@@ -39,7 +43,7 @@ export class DomicilioService {
    * Crea un nuevo domicilio.
    * @param domicilio Datos del domicilio a crear
    */
-  createDomicilio(domicilio: Domicilio): Observable<ApiResponse<Domicilio>> {
+  createDomicilio(domicilio: DomicilioRequest): Observable<ApiResponse<Domicilio>> {
     return this.http
       .post<ApiResponse<Domicilio>>(this.baseUrl, domicilio)
       .pipe(catchError(this.handleError.handleError));
@@ -50,7 +54,10 @@ export class DomicilioService {
    * @param id ID del domicilio
    * @param domicilio Datos actualizados
    */
-  updateDomicilio(id: number, domicilio: Partial<Domicilio>): Observable<ApiResponse<Domicilio>> {
+  updateDomicilio(
+    id: number,
+    domicilio: Partial<DomicilioRequest>,
+  ): Observable<ApiResponse<Domicilio>> {
     return this.http
       .put<ApiResponse<Domicilio>>(`${this.baseUrl}?id=${id}`, domicilio)
       .pipe(catchError(this.handleError.handleError));

--- a/src/app/core/services/pago.service.ts
+++ b/src/app/core/services/pago.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Observable, catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
-import { Pago } from '../../shared/models/pago.model';
+import { Pago, PagoCreate, PagoUpdate } from '../../shared/models/pago.model';
 import { HandleErrorService } from './handle-error.service';
 
 @Injectable({ providedIn: 'root' })
@@ -12,7 +12,7 @@ export class PagoService {
 
   constructor(private http: HttpClient, private handleError: HandleErrorService) {}
 
-  createPago(payload: Pago): Observable<ApiResponse<Pago>> {
+  createPago(payload: PagoCreate): Observable<ApiResponse<Pago>> {
     console.log('Creating pago with payload:', payload);
     return this.http
       .post<ApiResponse<Pago>>(this.baseUrl, payload)
@@ -31,7 +31,7 @@ export class PagoService {
       .pipe(catchError(this.handleError.handleError));
   }
 
-  updatePago(id: number, payload: Partial<Pago>): Observable<ApiResponse<Pago>> {
+  updatePago(id: number, payload: PagoUpdate): Observable<ApiResponse<Pago>> {
     return this.http
       .put<ApiResponse<Pago>>(`${this.baseUrl}?id=${id}`, payload)
       .pipe(catchError(this.handleError.handleError));

--- a/src/app/core/services/pedido-cliente.service.spec.ts
+++ b/src/app/core/services/pedido-cliente.service.spec.ts
@@ -54,7 +54,9 @@ describe('PedidoClienteService', () => {
   it('gets pedido cliente', () => {
     const mock = { code: 200, message: 'ok', data: {} };
     service.getPedidoCliente(3, 4).subscribe((res) => expect(res).toEqual(mock));
-    const req = http.expectOne(`${baseUrl}/3/4`);
+    const req = http.expectOne(
+      `${baseUrl}?pedido_id=3&cliente_id=4`,
+    );
     expect(req.request.method).toBe('GET');
     req.flush(mock);
   });
@@ -64,7 +66,7 @@ describe('PedidoClienteService', () => {
       next: () => fail('should have failed'),
       error: (err) => expect(err).toBeTruthy(),
     });
-    const req = http.expectOne(`${baseUrl}/3/4`);
+    const req = http.expectOne(`${baseUrl}?pedido_id=3&cliente_id=4`);
     req.error(new ErrorEvent('Network error'));
     expect(mockHandleErrorService.handleError).toHaveBeenCalled();
   });

--- a/src/app/core/services/pedido-cliente.service.ts
+++ b/src/app/core/services/pedido-cliente.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
@@ -19,9 +19,15 @@ export class PedidoClienteService {
       .pipe(catchError(this.handleError.handleError));
   }
   /** Obtiene los pedidos de un cliente */
-  getPedidoCliente(pedidoId: number, clienteId: number): Observable<ApiResponse<PedidoCliente>> {
+  getPedidoCliente(
+    pedidoId: number,
+    clienteId: number,
+  ): Observable<ApiResponse<PedidoCliente>> {
+    const params = new HttpParams()
+      .set('pedido_id', pedidoId.toString())
+      .set('cliente_id', clienteId.toString());
     return this.http
-      .get<ApiResponse<PedidoCliente>>(`${this.baseUrl}/${pedidoId}/${clienteId}`)
+      .get<ApiResponse<PedidoCliente>>(this.baseUrl, { params })
       .pipe(catchError(this.handleError.handleError));
   }
 }

--- a/src/app/core/services/pedido.service.spec.ts
+++ b/src/app/core/services/pedido.service.spec.ts
@@ -31,7 +31,7 @@ describe('PedidoService', () => {
   });
 
   it('creates pedido', () => {
-    const pedido = { total: 100 } as any;
+    const pedido = { delivery: true } as any;
     const mock = { code: 200, message: 'ok', data: {} };
     service.createPedido(pedido).subscribe((res) => expect(res).toEqual(mock));
     const req = http.expectOne(baseUrl);
@@ -41,7 +41,7 @@ describe('PedidoService', () => {
   });
 
   it('handles error on createPedido', () => {
-    const pedido = { total: 100 } as any;
+    const pedido = { delivery: true } as any;
     service.createPedido(pedido).subscribe({
       next: () => fail('should have failed'),
       error: (err) => expect(err).toBeTruthy(),

--- a/src/app/core/services/pedido.service.ts
+++ b/src/app/core/services/pedido.service.ts
@@ -3,7 +3,11 @@ import { Injectable } from '@angular/core';
 import { Observable, catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { ApiResponse } from '../../shared/models/api-response.model';
-import { Pedido, PedidoDetalle } from '../../shared/models/pedido.model';
+import {
+  Pedido,
+  PedidoDetalle,
+  PedidoCreate,
+} from '../../shared/models/pedido.model';
 import { HandleErrorService } from './handle-error.service';
 
 @Injectable({ providedIn: 'root' })
@@ -12,7 +16,7 @@ export class PedidoService {
 
   constructor(private http: HttpClient, private handleError: HandleErrorService) {}
 
-  createPedido(pedido: Partial<Pedido>): Observable<ApiResponse<Pedido>> {
+  createPedido(pedido: PedidoCreate): Observable<ApiResponse<Pedido>> {
     return this.http
       .post<ApiResponse<Pedido>>(this.baseUrl, pedido)
       .pipe(catchError(this.handleError.handleError));

--- a/src/app/core/services/producto-pedido.service.spec.ts
+++ b/src/app/core/services/producto-pedido.service.spec.ts
@@ -31,36 +31,26 @@ describe('ProductoPedidoService', () => {
   });
 
   it('creates producto pedido', () => {
-    const payload: any = {
-      pedidoId: 1,
-      DETALLES_PRODUCTOS: [
-        { PK_ID_PRODUCTO: 1, NOMBRE: 'A', CANTIDAD: 1, PRECIO_UNITARIO: 10, SUBTOTAL: 10 },
-      ],
-    };
+    const detalles = [
+      { PK_ID_PRODUCTO: 1, NOMBRE: 'A', CANTIDAD: 1, PRECIO_UNITARIO: 10, SUBTOTAL: 10 },
+    ];
     const mock = { code: 200, message: 'ok', data: {} };
-    service.create(payload).subscribe((res) => expect(res).toEqual(mock));
-    const req = http.expectOne(baseUrl);
+    service.create(1, detalles).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?pedido_id=1`);
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toEqual({
-      pedidoId: undefined,
-      detallesProductos: payload.DETALLES_PRODUCTOS,
-    });
-    expect(Array.isArray(req.request.body.DETALLES_PRODUCTOS)).toBe(false);
+    expect(req.request.body).toEqual({ detallesProductos: detalles });
     req.flush(mock);
   });
 
   it('handles error on create', () => {
-    const payload: any = {
-      pedidoId: 1,
-      DETALLES_PRODUCTOS: [
-        { PK_ID_PRODUCTO: 1, NOMBRE: 'A', CANTIDAD: 1, PRECIO_UNITARIO: 10, SUBTOTAL: 10 },
-      ],
-    };
-    service.create(payload).subscribe({
+    const detalles = [
+      { PK_ID_PRODUCTO: 1, NOMBRE: 'A', CANTIDAD: 1, PRECIO_UNITARIO: 10, SUBTOTAL: 10 },
+    ];
+    service.create(1, detalles).subscribe({
       next: () => fail('should have failed'),
       error: (err) => expect(err).toBeTruthy(),
     });
-    const req = http.expectOne(baseUrl);
+    const req = http.expectOne(`${baseUrl}?pedido_id=1`);
     req.error(new ErrorEvent('Network error'));
     expect(mockHandleErrorService.handleError).toHaveBeenCalled();
   });

--- a/src/app/core/services/producto-pedido.service.ts
+++ b/src/app/core/services/producto-pedido.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { catchError } from 'rxjs';
 import { environment } from '../../../environments/environment';
@@ -24,13 +24,15 @@ export class ProductoPedidoService {
 
   constructor(private http: HttpClient, private handleError: HandleErrorService) {}
 
-  create(data: { PK_ID_PEDIDO: number; DETALLES_PRODUCTOS: any[] }) {
-    const body = {
-      pedidoId: data.PK_ID_PEDIDO,
-      detallesProductos: data.DETALLES_PRODUCTOS,
-    };
+  create(pedidoId: number, detallesProductos: any[]) {
+    const params = new HttpParams().set('pedido_id', pedidoId.toString());
+    const body = { detallesProductos };
     return this.http
-      .post<ApiResponse<any>>(`${this.baseUrl}/producto_pedido`, body)
+      .post<ApiResponse<any>>(
+        `${this.baseUrl}/producto_pedido`,
+        body,
+        { params },
+      )
       .pipe(catchError(this.handleError.handleError));
   }
 }

--- a/src/app/core/services/producto.service.spec.ts
+++ b/src/app/core/services/producto.service.spec.ts
@@ -40,13 +40,12 @@ describe('ProductoService', () => {
   });
 
   it('creates producto', () => {
-    const form = new FormData();
-    form.append('nombre', 'test');
+    const producto = { nombre: 'test', precio: 1, cantidad: 1 } as any;
     const mock = { code: 200, message: 'ok', data: {} };
-    service.createProducto(form).subscribe((res) => expect(res).toEqual(mock));
+    service.createProducto(producto).subscribe((res) => expect(res).toEqual(mock));
     const req = http.expectOne(baseUrl);
     expect(req.request.method).toBe('POST');
-    expect(req.request.body).toBe(form);
+    expect(req.request.body).toEqual(producto);
     req.flush(mock);
   });
 
@@ -59,12 +58,12 @@ describe('ProductoService', () => {
   });
 
   it('updates producto', () => {
-    const form = new FormData();
+    const producto = { nombre: 't', precio: 1, cantidad: 1 } as any;
     const mock = { code: 200, message: 'ok', data: {} };
-    service.updateProducto(3, form).subscribe((res) => expect(res).toEqual(mock));
+    service.updateProducto(3, producto).subscribe((res) => expect(res).toEqual(mock));
     const req = http.expectOne(`${baseUrl}?id=3`);
     expect(req.request.method).toBe('PUT');
-    expect(req.request.body).toBe(form);
+    expect(req.request.body).toEqual(producto);
     req.flush(mock);
   });
 
@@ -79,8 +78,8 @@ describe('ProductoService', () => {
   });
 
   it('handles error on createProducto', () => {
-    const form = new FormData();
-    service.createProducto(form).subscribe({
+    const producto = { nombre: 't', precio: 1, cantidad: 1 } as any;
+    service.createProducto(producto).subscribe({
       next: () => fail('should have failed'),
       error: (err) => expect(err).toBeTruthy(),
     });
@@ -101,8 +100,8 @@ describe('ProductoService', () => {
   });
 
   it('handles error on updateProducto', () => {
-    const form = new FormData();
-    service.updateProducto(3, form).subscribe({
+    const producto = { nombre: 't', precio: 1, cantidad: 1 } as any;
+    service.updateProducto(3, producto).subscribe({
       next: () => fail('should have failed'),
       error: (err) => expect(err).toBeTruthy(),
     });

--- a/src/app/core/services/producto.service.ts
+++ b/src/app/core/services/producto.service.ts
@@ -27,12 +27,10 @@ export class ProductoService {
 
   /**
    * Crea un nuevo producto
-   * @param formData FormData con los datos del producto
-   * @returns
    */
-  createProducto(formData: FormData): Observable<ApiResponse<Producto>> {
+  createProducto(producto: Producto): Observable<ApiResponse<Producto>> {
     return this.http
-      .post<ApiResponse<Producto>>(`${this.baseUrl}`, formData)
+      .post<ApiResponse<Producto>>(`${this.baseUrl}`, producto)
       .pipe(catchError(this.handleError.handleError));
   }
 
@@ -50,11 +48,15 @@ export class ProductoService {
   /**
    * Actualiza un producto por ID
    */
-  updateProducto(id: number, formData: FormData): Observable<ApiResponse<Producto>> {
+  updateProducto(id: number, producto: Producto): Observable<ApiResponse<Producto>> {
     return this.http
-      .put<ApiResponse<Producto>>(`${this.baseUrl}`, formData, {
-        params: { id: id.toString() },
-      })
+      .put<ApiResponse<Producto>>(
+        `${this.baseUrl}`,
+        producto,
+        {
+          params: { id: id.toString() },
+        },
+      )
       .pipe(catchError(this.handleError.handleError));
   }
 }

--- a/src/app/core/services/reserva.service.spec.ts
+++ b/src/app/core/services/reserva.service.spec.ts
@@ -4,7 +4,11 @@ import { throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { HandleErrorService } from '../../core/services/handle-error.service';
 import { UserService } from '../../core/services/user.service';
-import { mockReservaBody, mockReservaResponse } from '../../shared/mocks/reserva.mocks';
+import {
+  mockReserva,
+  mockReservaBody,
+  mockReservaResponse,
+} from '../../shared/mocks/reserva.mocks';
 import { ApiResponse } from '../../shared/models/api-response.model';
 import { Reserva } from '../../shared/models/reserva.model';
 import { ReservaService } from './reserva.service';
@@ -65,12 +69,12 @@ describe('ReservaService', () => {
   });
 
   it('should update a reserva successfully', () => {
-    service.actualizarReserva(mockReservaBody.reservaId!, mockReservaBody).subscribe((response) => {
+    service.actualizarReserva(mockReserva.reservaId!, mockReservaBody).subscribe((response) => {
       expect(response).toEqual(mockReservaResponse);
     });
 
     const req = httpMock.expectOne(
-      `${environment.apiUrl}/reservas?id=${mockReservaBody.reservaId}`,
+      `${environment.apiUrl}/reservas?id=${mockReserva.reservaId}`,
     );
     expect(req.request.method).toBe('PUT');
     expect(req.request.body).toEqual(mockReservaBody);
@@ -136,14 +140,14 @@ describe('ReservaService', () => {
   });
 
   it('should handle API error when updating a reserva', () => {
-    service.actualizarReserva(mockReservaBody.reservaId!, mockReservaBody).subscribe({
+    service.actualizarReserva(mockReserva.reservaId!, mockReservaBody).subscribe({
       error: (error) => {
         expect(error).toBeTruthy();
       },
     });
 
     const req = httpMock.expectOne(
-      `${environment.apiUrl}/reservas?id=${mockReservaBody.reservaId}`,
+      `${environment.apiUrl}/reservas?id=${mockReserva.reservaId}`,
     );
     req.error(new ErrorEvent('API error'));
     expect(handleErrorService.handleError).toHaveBeenCalled();

--- a/src/app/core/services/reserva.service.ts
+++ b/src/app/core/services/reserva.service.ts
@@ -5,7 +5,7 @@ import { environment } from '../../../environments/environment';
 import { HandleErrorService } from '../../core/services/handle-error.service';
 import { UserService } from '../../core/services/user.service';
 import { ApiResponse } from '../../shared/models/api-response.model';
-import { Reserva } from '../../shared/models/reserva.model';
+import { Reserva, ReservaCreate, ReservaUpdate } from '../../shared/models/reserva.model';
 
 @Injectable({
   providedIn: 'root',
@@ -19,7 +19,7 @@ export class ReservaService {
     private handleError: HandleErrorService,
   ) {}
 
-  crearReserva(reserva: Reserva): Observable<ApiResponse<Reserva>> {
+  crearReserva(reserva: ReservaCreate): Observable<ApiResponse<Reserva>> {
     return this.http
       .post<ApiResponse<Reserva>>(`${this.baseUrl}/reservas`, reserva)
       .pipe(catchError(this.handleError.handleError));
@@ -31,7 +31,10 @@ export class ReservaService {
       .pipe(catchError(this.handleError.handleError));
   }
 
-  actualizarReserva(reservaId: number, reserva: Reserva): Observable<ApiResponse<Reserva>> {
+  actualizarReserva(
+    reservaId: number,
+    reserva: ReservaUpdate,
+  ): Observable<ApiResponse<Reserva>> {
     return this.http
       .put<ApiResponse<Reserva>>(`${this.baseUrl}/reservas?id=${reservaId}`, reserva)
       .pipe(catchError(this.handleError.handleError));

--- a/src/app/modules/admin/productos/crear-producto/crear-producto.component.ts
+++ b/src/app/modules/admin/productos/crear-producto/crear-producto.component.ts
@@ -24,7 +24,6 @@ export class CrearProductoComponent {
     categoria: '',
     subcategoria: '',
   };
-  imagenSeleccionada: File | null = null;
   mensaje: string = '';
   estadoProducto = estadoProducto;
   productoId: string | null = null;
@@ -46,7 +45,14 @@ export class CrearProductoComponent {
   }
   seleccionarImagen(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.imagenSeleccionada = input.files?.[0] || null;
+    const file = input.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        this.producto.imagenBase64 = reader.result as string;
+      };
+      reader.readAsDataURL(file);
+    }
   }
 
   crearProducto(): void {
@@ -55,9 +61,7 @@ export class CrearProductoComponent {
       return;
     }
 
-    const formData = this.crearFormData(this.producto);
-
-    this.productoService.createProducto(formData).subscribe((response) => {
+    this.productoService.createProducto(this.producto).subscribe((response) => {
       if (response.code === 201) {
         this.mensaje = 'Producto creado con éxito';
         setTimeout(() => this.router.navigate(['/admin/productos']), 2000);
@@ -74,9 +78,9 @@ export class CrearProductoComponent {
   actualizarProducto(): void {
     if (!this.productoId) return;
 
-    const formData = this.crearFormData(this.producto);
-
-    this.productoService.updateProducto(Number(this.productoId), formData).subscribe((response) => {
+    this.productoService
+      .updateProducto(Number(this.productoId), this.producto)
+      .subscribe((response) => {
       if (response.code === 200) {
         this.mensaje = 'Producto actualizado con éxito';
         setTimeout(() => this.router.navigate(['/admin/productos']), 2000);
@@ -84,23 +88,5 @@ export class CrearProductoComponent {
     });
   }
 
-  private crearFormData(producto: Producto): FormData {
-    const formData = new FormData();
-
-    // Convertimos los nombres de las propiedades a mayúsculas para el backend
-    formData.append('NOMBRE', producto.nombre);
-    formData.append('CALORIAS', producto.calorias?.toString() || '');
-    formData.append('DESCRIPCION', producto.descripcion || '');
-    formData.append('PRECIO', producto.precio.toString());
-    formData.append('ESTADO_PRODUCTO', producto.estadoProducto || 'DISPONIBLE');
-    formData.append('CANTIDAD', producto.cantidad.toString());
-    formData.append('CATEGORIA', producto.categoria || '');
-    formData.append('SUBCATEGORIA', producto.subcategoria || '');
-
-    if (this.imagenSeleccionada) {
-      formData.append('IMAGEN', this.imagenSeleccionada);
-    }
-
-    return formData;
-  }
+  // Ya no se requiere conversión a FormData; el backend acepta JSON con imagenBase64
 }

--- a/src/app/modules/client/carrito/carrito.component.spec.ts
+++ b/src/app/modules/client/carrito/carrito.component.spec.ts
@@ -279,8 +279,6 @@ describe('CarritoComponent', () => {
     await (component as any).finalizeOrder(1, null);
     expect(pedidoServiceMock.createPedido).toHaveBeenCalledWith({
       delivery: false,
-      pagoId: 1,
-      estadoPedido: 'PENDIENTE',
     });
     expect(pedidoServiceMock.assignPago).not.toHaveBeenCalled();
     expect(pedidoServiceMock.assignDomicilio).not.toHaveBeenCalled();
@@ -301,8 +299,6 @@ describe('CarritoComponent', () => {
     await (component as any).finalizeOrder(2, 7);
     expect(pedidoServiceMock.createPedido).toHaveBeenCalledWith({
       delivery: true,
-      pagoId: 2,
-      estadoPedido: 'PENDIENTE',
     });
     expect(pedidoServiceMock.assignPago).not.toHaveBeenCalled();
     expect(pedidoServiceMock.assignDomicilio).toHaveBeenCalledWith(50, 7);

--- a/src/app/modules/client/carrito/carrito.component.ts
+++ b/src/app/modules/client/carrito/carrito.component.ts
@@ -19,7 +19,10 @@ import { UserService } from '../../../core/services/user.service';
 
 import { estadoPago } from '../../../shared/constants';
 import { Cliente } from '../../../shared/models/cliente.model';
-import { Domicilio } from '../../../shared/models/domicilio.model';
+import {
+  Domicilio,
+  DomicilioRequest,
+} from '../../../shared/models/domicilio.model';
 import { MetodosPago } from '../../../shared/models/metodo-pago.model';
 import { Producto } from '../../../shared/models/producto.model';
 
@@ -169,11 +172,10 @@ export class CarritoComponent implements OnInit, OnDestroy {
       observacion || 'Sin observaciones'
     }`;
 
-    const nuevoDomicilio: Domicilio = {
+    const nuevoDomicilio: DomicilioRequest = {
       direccion: cliente.direccion,
       telefono: cliente.telefono,
       estadoPago: estadoPago.PENDIENTE,
-      entregado: false,
       fechaDomicilio: fechaHoy,
       observaciones: obs,
       createdBy: `Usuario ${clienteId}`,
@@ -194,11 +196,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
     try {
       const pedidoRes = await firstValueFrom(
         this.pedidoService
-          .createPedido({
-            delivery: domicilioId !== null,
-            pagoId: methodId,
-            estadoPedido: estadoPago.PENDIENTE,
-          })
+          .createPedido({ delivery: domicilioId !== null })
           .pipe(takeUntil(this.destroy$)),
       );
       const pedidoId = pedidoRes.data.pedidoId!;
@@ -213,7 +211,7 @@ export class CarritoComponent implements OnInit, OnDestroy {
 
       await firstValueFrom(
         this.productoPedidoService
-          .create({ PK_ID_PEDIDO: pedidoId, DETALLES_PRODUCTOS: detalles })
+          .create(pedidoId, detalles)
           .pipe(takeUntil(this.destroy$)),
       );
 

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.spec.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.spec.ts
@@ -316,7 +316,7 @@ describe('ConsultarDomicilioComponent', () => {
 
       component.marcarEntregado(domicilio);
 
-      expect(domicilioService.updateDomicilio).toHaveBeenCalledWith(1, { entregado: true });
+      expect(domicilioService.updateDomicilio).toHaveBeenCalledWith(1, {});
       expect(domicilio.entregado).toBe(true);
     });
 

--- a/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
+++ b/src/app/modules/public/domicilios/consultar-domicilios/consultar-domicilios.component.ts
@@ -127,7 +127,7 @@ export class ConsultarDomicilioComponent implements OnInit {
   }
   marcarEntregado(domicilio: Domicilio): void {
     this.domicilioService
-      .updateDomicilio(domicilio.domicilioId!, { entregado: true })
+      .updateDomicilio(domicilio.domicilioId!, {})
       .subscribe((response) => {
         if (response.code === 200) {
           domicilio.entregado = true;

--- a/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.ts
+++ b/src/app/modules/public/reservas/crear-reserva/crear-reserva.component.ts
@@ -8,7 +8,7 @@ import { ReservaService } from '../../../../core/services/reserva.service';
 import { TrabajadorService } from '../../../../core/services/trabajador.service';
 import { UserService } from '../../../../core/services/user.service';
 import { estadoReserva } from '../../../../shared/constants';
-import { Reserva } from '../../../../shared/models/reserva.model';
+import { ReservaCreate } from '../../../../shared/models/reserva.model';
 import { ClienteService } from './../../../../core/services/cliente.service';
 
 @Component({
@@ -107,21 +107,7 @@ export class CrearReservaComponent implements OnInit {
     const [anio, mes, dia] = this.fechaReserva.split('-');
     const fechaReservaFormateada = `${anio}-${mes.padStart(2, '0')}-${dia.padStart(2, '0')}`;
 
-    const reserva: Reserva = {
-      createdAt: timestamp,
-      updatedAt: timestamp,
-      createdBy:
-        userRole === 'Administrador'
-          ? `${this.rol} - ${this.nombreTrabajador}`
-          : userRole
-          ? `Cliente - ${this.nombreCompleto}`
-          : 'Anónimo',
-      updatedBy:
-        userRole === 'Administrador'
-          ? `${this.rol} - ${this.nombreTrabajador}`
-          : userRole
-          ? `Cliente - ${this.nombreCompleto}`
-          : 'Anónimo',
+    const reserva: ReservaCreate = {
       documentoCliente:
         userRole === 'Administrador'
           ? Number(userId)

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.spec.ts
@@ -102,7 +102,7 @@ describe('RutaDomicilioComponent', () => {
   it('should mark domicilio as finalizado when marcarFinalizado is called', () => {
     domicilioService.updateDomicilio.mockReturnValue(of(mockDomicilioRespone));
     component.marcarFinalizado();
-    expect(domicilioService.updateDomicilio).toHaveBeenCalledWith(1, { entregado: true });
+    expect(domicilioService.updateDomicilio).toHaveBeenCalledWith(1, {});
     expect(toastrService.success).toHaveBeenCalledWith('Domicilio marcado como finalizado');
   });
 

--- a/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
+++ b/src/app/modules/trabajadores/domicilios/ruta-domicilio/ruta-domicilio.component.ts
@@ -178,7 +178,7 @@ export class RutaDomicilioComponent implements OnInit {
       console.error('No se encontró el ID del domicilio.');
       return;
     }
-    this.domicilioService.updateDomicilio(this.domicilioId, { entregado: true }).subscribe({
+    this.domicilioService.updateDomicilio(this.domicilioId, {}).subscribe({
       next: (response) => {
         this.toastrService.success('Domicilio marcado como finalizado');
         this.logger.log(LogLevel.INFO, 'Domicilio marcado como finalizado', response);
@@ -225,9 +225,6 @@ export class RutaDomicilioComponent implements OnInit {
                   horaPago: horaHHMMSS_Bogota(ahora),
                   metodoPagoId: this.devolverMetodoPago(metodoPagoSeleccionado),
                   monto: this.totalPedido,
-                  pagoId: 0,
-                  updatedAt: fechaHoraDDMMYYYY_HHMMSS_Bogota(ahora),
-                  updatedBy: `${this.userService.getUserRole()} - ${this.userService.getUserId()}`,
                 })
                 .subscribe({
                   next: (response) => {

--- a/src/app/shared/mocks/domicilio.mock.ts
+++ b/src/app/shared/mocks/domicilio.mock.ts
@@ -1,6 +1,6 @@
 import { estadoPago } from '../constants';
 import { ApiResponse } from '../models/api-response.model';
-import { Domicilio } from '../models/domicilio.model';
+import { Domicilio, DomicilioRequest } from '../models/domicilio.model';
 
 export const mockDomicilioRespone: ApiResponse<Domicilio> = {
   code: 200,
@@ -53,12 +53,11 @@ export const mockDomiciliosRespone: ApiResponse<Domicilio[]> = {
   ],
 };
 
-export const mockDomicilioBody: Domicilio = {
+export const mockDomicilioBody: DomicilioRequest = {
   fechaDomicilio: '2024-12-30',
   direccion: 'Carrera 45 #10-20',
   telefono: '3006543210',
   estadoPago: estadoPago.PENDIENTE,
-  entregado: false,
   observaciones: 'Requiere cambio',
   createdBy: 'Administrador - Bryan Luis',
 };

--- a/src/app/shared/mocks/mocks.spec.ts
+++ b/src/app/shared/mocks/mocks.spec.ts
@@ -56,7 +56,7 @@ describe('shared mocks', () => {
   it('domicilio mocks', () => {
     expect(mockDomicilioRespone.data.telefono).toBe('3042449339');
     expect(mockDomiciliosRespone.data).toHaveLength(2);
-    expect(mockDomicilioBody.entregado).toBe(false);
+    expect(mockDomicilioBody.direccion).toBe('Carrera 45 #10-20');
   });
 
   it('error mocks', () => {

--- a/src/app/shared/mocks/pago.mock.ts
+++ b/src/app/shared/mocks/pago.mock.ts
@@ -1,6 +1,6 @@
 import { estadoPago } from '../constants';
 import { ApiResponse } from '../models/api-response.model';
-import { Pago } from '../models/pago.model';
+import { Pago, PagoCreate } from '../models/pago.model';
 
 export const mockPagosResponse: ApiResponse<Pago[]> = {
   code: 200,
@@ -42,12 +42,10 @@ export const mockPagoResponse: ApiResponse<Pago> = {
     updatedBy: 'Administrador - Bryan Luis',
   },
 };
-export const mockPagoBody: Pago = {
+export const mockPagoBody: PagoCreate = {
   fechaPago: '2024-12-24',
-  updatedAt: '31-12-0000 19:03:44',
   horaPago: '12:05:00',
   monto: 2000,
   estadoPago: estadoPago.PAGADO,
   metodoPagoId: 1,
-  updatedBy: 'Administrador - Bryan Luis',
 };

--- a/src/app/shared/mocks/reserva.mocks.ts
+++ b/src/app/shared/mocks/reserva.mocks.ts
@@ -1,6 +1,6 @@
 import { estadoReserva } from '../constants';
 import { ApiResponse } from '../models/api-response.model';
-import { Reserva } from '../models/reserva.model';
+import { Reserva, ReservaCreate } from '../models/reserva.model';
 
 export const mockReserva: Reserva = {
   reservaId: 1,
@@ -115,17 +115,13 @@ export const mockReservasUnordered: Reserva[] = [
   },
 ];
 
-export const mockReservaBody: Reserva = {
+export const mockReservaBody: ReservaCreate = {
   documentoCliente: 1015466494,
   telefono: '3042449339',
   fechaReserva: '2025-02-06',
   horaReserva: '10:00:00',
   personas: 3,
   estadoReserva: estadoReserva.PENDIENTE,
-  createdAt: '2025-02-06T12:00:00.000Z',
-  createdBy: 'Administrador - Bryan Luis',
   indicaciones: 'Reserva de prueba',
   nombreCompleto: 'Bryan Luis',
-  updatedAt: '2025-02-06T12:00:00.000Z',
-  updatedBy: 'Administrador - Bryan Luis',
 };

--- a/src/app/shared/models/domicilio.model.ts
+++ b/src/app/shared/models/domicilio.model.ts
@@ -16,6 +16,16 @@ export interface Domicilio {
   trabajadorNombre?: string;
 }
 
+export type DomicilioRequest = Omit<
+  Domicilio,
+  | 'entregado'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'domicilioId'
+  | 'trabajadorAsignado'
+  | 'trabajadorNombre'
+>;
+
 export interface DomicilioDetalle {
   cliente: {
     documento: number;

--- a/src/app/shared/models/pago.model.ts
+++ b/src/app/shared/models/pago.model.ts
@@ -10,3 +10,6 @@ export interface Pago {
   updatedAt?: string;
   updatedBy?: string;
 }
+
+export type PagoCreate = Omit<Pago, 'pagoId' | 'updatedAt' | 'updatedBy'>;
+export type PagoUpdate = Partial<PagoCreate>;

--- a/src/app/shared/models/pedido.model.ts
+++ b/src/app/shared/models/pedido.model.ts
@@ -12,6 +12,10 @@ export interface Pedido {
   updatedBy?: string;
 }
 
+export interface PedidoCreate {
+  delivery: boolean;
+}
+
 export interface PedidoDetalle {
   pedidoId: number;
   fechaPedido: string;

--- a/src/app/shared/models/producto.model.ts
+++ b/src/app/shared/models/producto.model.ts
@@ -7,7 +7,7 @@ export interface Producto {
   descripcion?: string;
   precio: number;
   estadoProducto?: estadoProducto;
-  imagen?: File | string;
+  imagenBase64?: string;
   cantidad: number;
   categoria?: string;
   subcategoria?: string;

--- a/src/app/shared/models/reserva.model.ts
+++ b/src/app/shared/models/reserva.model.ts
@@ -15,3 +15,10 @@ export interface Reserva {
   updatedAt: string;
   updatedBy: string;
 }
+
+export type ReservaCreate = Omit<
+  Reserva,
+  'reservaId' | 'createdAt' | 'createdBy' | 'updatedAt' | 'updatedBy'
+>;
+
+export type ReservaUpdate = ReservaCreate;


### PR DESCRIPTION
## Summary
- remove read-only fields from domicilio payloads
- restrict pago and pedido DTOs to writable fields
- send product images as Base64 JSON instead of FormData
- move pedido-cliente and producto-pedido identifiers to query params
- refine reserva payload types

## Testing
- `npm test` *(fails: No provider for _HttpClient, mismatched expectations, missing mocks)*
- `npm run lint` *(fails: Cannot find package '@angular-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68b79c8c5e0083259928fe73843536ea