### PR TITLE
test: ensure core services reach full coverage

### DIFF
--- a/src/app/core/services/producto.service.spec.ts
+++ b/src/app/core/services/producto.service.spec.ts
@@ -141,6 +141,16 @@ describe('ProductoService', () => {
     req.flush(mock);
   });
 
+  it('maps null list responses to an empty array', () => {
+    const mock = { code: 200, message: 'ok', data: null } as any;
+    service.getProductos().subscribe((res) => {
+      expect(Array.isArray(res.data)).toBe(true);
+      expect(res.data).toHaveLength(0);
+    });
+    const req = http.expectOne(`${baseUrl}`);
+    req.flush(mock);
+  });
+
   it('does not re-prefix data URL in getById', () => {
     const mock = {
       code: 200,

--- a/src/app/core/services/telemetry.service.spec.ts
+++ b/src/app/core/services/telemetry.service.spec.ts
@@ -316,4 +316,30 @@ describe('TelemetryService', () => {
     expect(() => svc.getEvents()).not.toThrow(); // readAll -> catch -> return []
     (localStorage as any).getItem = originalGet;
   });
+
+  it('readAll regresa [] cuando el valor almacenado no es un arreglo', () => {
+    const spy = jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('{"foo":1}');
+    try {
+      const result = (svc as any).readAll();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(0);
+      expect(spy).toHaveBeenCalledWith('app_telemetry_events');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('readAll captura excepciones de localStorage.getItem y devuelve []', () => {
+    const spy = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('get-fail');
+      });
+    try {
+      expect((svc as any).readAll()).toEqual([]);
+      expect(spy).toHaveBeenCalledWith('app_telemetry_events');
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- ensure ProductoService maps null list responses to an empty array
- add focused TelemetryService specs that exercise storage fallbacks and error handling

## Testing
- npm test -- --coverage --maxWorkers=50%


------
https://chatgpt.com/codex/tasks/task_e_68c9ce2883a883259750e325936caa35