### PR TITLE
test: expand service coverage

### DIFF
--- a/src/app/core/services/domicilio.service.spec.ts
+++ b/src/app/core/services/domicilio.service.spec.ts
@@ -42,6 +42,18 @@ describe('DomicilioService', () => {
   });
 
   describe('getDomicilios', () => {
+    it('should GET domicilios sin parámetros', () => {
+      const mockResponse = mockDomiciliosRespone;
+
+      service.getDomicilios().subscribe((response) => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne((req) => req.url === baseUrl && req.params.keys().length === 0);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockResponse);
+    });
+
     it('should GET domicilios with query params', () => {
       const mockResponse = mockDomiciliosRespone;
       const params = { filter: 'test' };

--- a/src/app/core/services/horario-trabajador.service.spec.ts
+++ b/src/app/core/services/horario-trabajador.service.spec.ts
@@ -23,11 +23,29 @@ describe('HorarioTrabajadorService', () => {
 
   afterEach(() => http.verify());
 
+  it('list sin filtros', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.list().subscribe((res) => expect(res).toEqual([]));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(mock);
+  });
+
   it('lists horarios with filters', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service.list({ documento: 123, dia: 'Lunes' }).subscribe((res) => expect(res).toEqual([]));
     const req = http.expectOne(`${baseUrl}?documento=123&dia=Lunes`);
     expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('list solo documento sin día', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.list({ documento: 456 }).subscribe((res) => expect(res).toEqual([]));
+    const req = http.expectOne(`${baseUrl}?documento=456`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.has('dia')).toBe(false);
     req.flush(mock);
   });
 
@@ -38,6 +56,24 @@ describe('HorarioTrabajadorService', () => {
     const req = http.expectOne(`${baseUrl}?documento=123&dia=Lunes`);
     expect(req.request.method).toBe('PUT');
     expect(req.request.body).toEqual(body);
+    req.flush(mock);
+  });
+
+  it('create horario', () => {
+    const body = { documento: 10, dia: 'Martes', horaInicio: '09:00', horaFin: '18:00' } as any;
+    const mock = { code: 201, message: 'created', data: {} };
+    service.create(body).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush(mock);
+  });
+
+  it('delete horario', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.delete(11).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=11`);
+    expect(req.request.method).toBe('DELETE');
     req.flush(mock);
   });
 });

--- a/src/app/core/services/nomina-trabajador.service.spec.ts
+++ b/src/app/core/services/nomina-trabajador.service.spec.ts
@@ -31,6 +31,15 @@ describe('NominaTrabajadorService', () => {
     req.flush(mock);
   });
 
+  it('listMes sin filtros', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.listMes().subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/mes`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(mock);
+  });
+
   it('lists por mes/anio', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service.listMes(9, 2025).subscribe((res) => expect(res).toEqual(mock));
@@ -42,12 +51,29 @@ describe('NominaTrabajadorService', () => {
   it('search con filtros', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service
-      .search({ documento: 101, actual: true, pagas: false, no_pagas: true, mes: 9, anio: 2025 })
+      .search({
+        documento: 101,
+        trabajador_id: 77,
+        actual: true,
+        pagas: false,
+        no_pagas: true,
+        mes: 9,
+        anio: 2025,
+      })
       .subscribe((res) => expect(res).toEqual(mock));
     const req = http.expectOne(
-      `${baseUrl}/search?documento=101&actual=true&pagas=false&no_pagas=true&mes=9&anio=2025`,
+      `${baseUrl}/search?documento=101&trabajador_id=77&actual=true&pagas=false&no_pagas=true&mes=9&anio=2025`,
     );
     expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('search sin filtros no agrega parámetros', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.search({} as any).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/search`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
     req.flush(mock);
   });
 
@@ -58,6 +84,24 @@ describe('NominaTrabajadorService', () => {
     const req = http.expectOne(baseUrl);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(body);
+    req.flush(mock);
+  });
+
+  it('update nomina-trabajador', () => {
+    const body = { detalles: 'editado' };
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.update(5, body).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=5`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual(body);
+    req.flush(mock);
+  });
+
+  it('delete nomina-trabajador', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.delete(8).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=8`);
+    expect(req.request.method).toBe('DELETE');
     req.flush(mock);
   });
 });

--- a/src/app/core/services/nomina.service.spec.ts
+++ b/src/app/core/services/nomina.service.spec.ts
@@ -23,6 +23,15 @@ describe('NominaService', () => {
 
   afterEach(() => http.verify());
 
+  it('list sin filtros no agrega parámetros', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.list().subscribe((res) => expect(res).toEqual([]));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(mock);
+  });
+
   it('lists nominas con filtros', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service
@@ -38,6 +47,24 @@ describe('NominaService', () => {
     service.updateEstado(1).subscribe((res) => expect(res).toEqual(mock.data));
     const req = http.expectOne(`${baseUrl}?id=1`);
     expect(req.request.method).toBe('PUT');
+    req.flush(mock);
+  });
+
+  it('crea nomina', () => {
+    const body = { fecha: '2025-09-01' } as any;
+    const mock = { code: 201, message: 'created', data: { nominaId: 2 } } as any;
+    service.create(body).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush(mock);
+  });
+
+  it('elimina nomina por id', () => {
+    const mock = { code: 200, message: 'deleted', data: {} } as any;
+    service.delete(9).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=9`);
+    expect(req.request.method).toBe('DELETE');
     req.flush(mock);
   });
 });

--- a/src/app/core/services/pedido.service.spec.ts
+++ b/src/app/core/services/pedido.service.spec.ts
@@ -140,11 +140,37 @@ describe('PedidoService', () => {
     req.flush(mockPedidosFiltroResponse);
   });
 
+  it('getPedidos sin filtros utiliza HttpParams vacío', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.getPedidos().subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne((r) => r.url === baseUrl && r.params.keys().length === 0);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
   it('updates estado of pedido', () => {
     service.updateEstado(77, 'TERMINADO').subscribe((res) => expect(res).toEqual({ code: 200 }));
     const req = http.expectOne(`${baseUrl}/actualizar-estado?pedido_id=77&estado=TERMINADO`);
     expect(req.request.method).toBe('PUT');
     expect(req.request.body).toBeNull();
     req.flush({ code: 200 });
+  });
+
+  it('updatePedido envía body parcial con id en query', () => {
+    const body = { estadoPedido: 'EN_CURSO' } as any;
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.updatePedido(5, body).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=5`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual(body);
+    req.flush(mock);
+  });
+
+  it('deletePedido envía id como query', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.deletePedido(9).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=9`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(mock);
   });
 });

--- a/src/app/core/services/precio-producto-hist.service.spec.ts
+++ b/src/app/core/services/precio-producto-hist.service.spec.ts
@@ -23,6 +23,15 @@ describe('PrecioProductoHistService', () => {
 
   afterEach(() => http.verify());
 
+  it('list sin filtros no agrega parámetros', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.list().subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}/precio_producto_hist`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(mock);
+  });
+
   it('lists with filters', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service.list(1, '2025-02-01').subscribe((res) => expect(res).toEqual(mock));

--- a/src/app/core/services/producto-pedido.service.spec.ts
+++ b/src/app/core/services/producto-pedido.service.spec.ts
@@ -69,4 +69,12 @@ describe('ProductoPedidoService', () => {
     expect(req.request.body).toEqual(mockProductoPedidoUpdateBody);
     req.flush({ code: 200 });
   });
+
+  it('deleteByPedido elimina productos por pedido', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.deleteByPedido(31).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?pedido_id=31`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(mock);
+  });
 });

--- a/src/app/core/services/producto.service.spec.ts
+++ b/src/app/core/services/producto.service.spec.ts
@@ -67,6 +67,7 @@ describe('ProductoService', () => {
       calorias: 500,
       descripcion: 'rico',
       estadoProducto: 'ACTIVO',
+      subcategoriaId: 9,
     } as any;
     const file = new Blob(['x'], { type: 'image/jpeg' }) as any as File;
     (file as any).name = 'b.jpg';
@@ -82,6 +83,7 @@ describe('ProductoService', () => {
     expect((fd as any).has('calorias')).toBe(true);
     expect((fd as any).has('descripcion')).toBe(true);
     expect((fd as any).has('estadoProducto')).toBe(true);
+    expect((fd as any).has('subcategoriaId')).toBe(true);
     expect((fd as any).has('imagen')).toBe(true);
     req.flush(mock);
   });
@@ -235,6 +237,7 @@ describe('ProductoService', () => {
       calorias: 300,
       descripcion: 'desc',
       estadoProducto: 'INACTIVO',
+      subcategoriaId: 4,
     } as any;
     const file = new Blob(['x'], { type: 'image/jpeg' }) as any as File;
     (file as any).name = 'c.jpg';
@@ -248,6 +251,7 @@ describe('ProductoService', () => {
     expect((fd as any).has('descripcion')).toBe(true);
     expect((fd as any).has('estadoProducto')).toBe(true);
     expect((fd as any).has('cantidad')).toBe(true);
+    expect((fd as any).has('subcategoriaId')).toBe(true);
     expect((fd as any).has('imagen')).toBe(true);
     req.flush(mock);
   });
@@ -294,5 +298,13 @@ describe('ProductoService', () => {
     expect(req.request.method).toBe('PUT');
     req.error(new ErrorEvent('Network error'));
     expect(mockHandleErrorService.handleError).toHaveBeenCalled();
+  });
+
+  it('deleteProducto elimina el recurso por id', () => {
+    const mock = { code: 200, message: 'ok', data: {} };
+    service.deleteProducto(12).subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(`${baseUrl}?id=12`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(mock);
   });
 });

--- a/src/app/core/services/reserva-contacto.service.spec.ts
+++ b/src/app/core/services/reserva-contacto.service.spec.ts
@@ -24,6 +24,15 @@ describe('ReservaContactoService', () => {
 
   afterEach(() => http.verify());
 
+  it('getContactos sin filtros no agrega query params', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.getContactos().subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl + '/reserva_contacto');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(mock);
+  });
+
   it('gets contactos by filtros', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service.getContactos({ documento_cliente: 101 }).subscribe((res) => expect(res).toEqual(mock));

--- a/src/app/core/services/reserva.service.spec.ts
+++ b/src/app/core/services/reserva.service.spec.ts
@@ -189,6 +189,38 @@ describe('ReservaService', () => {
     req.flush(mockResponse);
   });
 
+  it('should get reserva by parameters (restauranteId)', () => {
+    const mockResponse: ApiResponse<Reserva[]> = {
+      code: 200,
+      message: 'Reservas encontradas por restaurante',
+      data: [mockReservaBody],
+    };
+
+    service.getReservaByParameter(undefined, undefined, 7).subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/reservas/parameter?restaurante_id=7`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+
+  it('should get reserva by parameters (día)', () => {
+    const mockResponse: ApiResponse<Reserva[]> = {
+      code: 200,
+      message: 'Reservas encontradas por día',
+      data: [mockReservaBody],
+    };
+
+    service.getReservaByParameter(undefined, undefined, undefined, 'Lunes').subscribe((response) => {
+      expect(response).toEqual(mockResponse);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/reservas/parameter?dia=Lunes`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockResponse);
+  });
+
   it('should handle API error when creating a reserva', () => {
     service.crearReserva(mockReservaBody).subscribe({
       error: (error) => {

--- a/src/app/core/services/restaurante-dia.service.spec.ts
+++ b/src/app/core/services/restaurante-dia.service.spec.ts
@@ -23,6 +23,15 @@ describe('RestauranteDiaService', () => {
 
   afterEach(() => http.verify());
 
+  it('list sin filtros no agrega parámetros', () => {
+    const mock = { code: 200, message: 'ok', data: [] };
+    service.list().subscribe((res) => expect(res).toEqual(mock));
+    const req = http.expectOne(baseUrl);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.keys().length).toBe(0);
+    req.flush(mock);
+  });
+
   it('lists con filtros', () => {
     const mock = { code: 200, message: 'ok', data: [] };
     service.list(1, 'Lunes').subscribe((res) => expect(res).toEqual(mock));

--- a/src/app/core/services/trabajador.service.spec.ts
+++ b/src/app/core/services/trabajador.service.spec.ts
@@ -141,4 +141,17 @@ describe('TrabajadorService', () => {
       req.flush({ code: 200, message: 'ok', data: mockTrabajadorResponse.data });
     });
   });
+
+  describe('deleteTrabajador', () => {
+    it('should DELETE a trabajador by documento', () => {
+      const documento = mockTrabajadorResponse.data.documentoTrabajador;
+      const mockResponse = { code: 200, message: 'ok', data: {} } as any;
+      service.deleteTrabajador(documento).subscribe((res) => {
+        expect(res).toEqual(mockResponse);
+      });
+      const req = httpMock.expectOne(`${baseUrl}/trabajadores?id=${documento}`);
+      expect(req.request.method).toBe('DELETE');
+      req.flush(mockResponse);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add missing branch coverage cases for multiple core services including reservas, pedidos, productos y nómina
- exercise optional parameter combinations and CRUD paths to ensure storage-related branches are covered
- add deletion tests where absent to cover remaining code paths in service wrappers

## Testing
- `npm test` *(fails: local Jest binary unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9cfab63883258a0260a42f853687