### PR TITLE
test: improve home component coverage

### DIFF
--- a/src/app/modules/public/home/home.component.spec.ts
+++ b/src/app/modules/public/home/home.component.spec.ts
@@ -4,10 +4,14 @@ import { TransferState } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 
 import { CartService } from '../../../core/services/cart.service';
+import { TelemetryService } from '../../../core/services/telemetry.service';
 import { UserService } from '../../../core/services/user.service';
+import { RolTrabajador } from '../../../shared/constants';
+import { ProductoVendido } from '../../../shared/models/telemetry.model';
+import * as imageUtils from '../../../shared/utils/image.utils';
 import { HomeComponent } from './home.component';
 
 class UserServiceStub {
@@ -38,6 +42,7 @@ describe('HomeComponent', () => {
   let hasKeyReturn: boolean;
   let setCalled: boolean;
   let tsStub: { hasKey: () => boolean; set: () => void };
+  let telemetryStub: { getProductosPopulares: jest.Mock };
 
   beforeEach(async () => {
     // Mock de IntersectionObserver global
@@ -58,6 +63,9 @@ describe('HomeComponent', () => {
         setCalled = true;
       },
     };
+    telemetryStub = {
+      getProductosPopulares: jest.fn(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [HomeComponent, RouterTestingModule, HttpClientTestingModule],
@@ -65,12 +73,17 @@ describe('HomeComponent', () => {
         { provide: UserService, useClass: UserServiceStub },
         { provide: CartService, useClass: CartServiceStub },
         { provide: TransferState, useValue: tsStub },
+        { provide: TelemetryService, useValue: telemetryStub },
       ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     userStub = TestBed.inject(UserService) as unknown as UserServiceStub;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('debería crearse', () => {
@@ -168,7 +181,7 @@ describe('HomeComponent', () => {
     flush(); // Flush all pending timers
 
     // Verificar que el TransferState se setea correctamente (solo si no es browser)
-    if (!isPlatformBrowser(component.platformId)) {
+    if (!isPlatformBrowser((component as any).platformId)) {
       expect(setCalled).toBe(true);
     }
 
@@ -266,5 +279,192 @@ describe('HomeComponent', () => {
     fixture.detectChanges();
     const hero = fixture.debugElement.query(By.css('.home-hero'));
     expect(hero).toBeTruthy();
+  });
+
+  it('determina correctamente si el usuario es cliente y si está logueado', () => {
+    userStub.setUserRole(null);
+    expect(component.isClient).toBe(true);
+    expect(component.isLoggedIn).toBe(false);
+
+    userStub.setUserRole('Cliente');
+    expect(component.isLoggedIn).toBe(true);
+    expect(component.isClient).toBe(true);
+
+    userStub.setUserRole(RolTrabajador.RolMesero);
+    expect(component.isClient).toBe(false);
+  });
+
+  it('genera las tarjetas correctas para clientes y trabajadores', () => {
+    component.cartCount = 2;
+    userStub.setUserRole('Cliente');
+
+    const clientCards = component.webViewCards;
+    expect(clientCards.find((card) => card.type === 'carrito')).toBeTruthy();
+    expect(clientCards.find((card) => card.type === 'pedidos')).toBeTruthy();
+    expect(clientCards.find((card) => card.type === 'perfil-cliente')).toBeTruthy();
+    expect(clientCards.find((card) => card.type === 'perfil-trabajador')).toBeFalsy();
+
+    userStub.setUserRole(RolTrabajador.RolCocinero);
+    const workerCards = component.webViewCards;
+    expect(workerCards.find((card) => card.type === 'perfil-trabajador')).toBeTruthy();
+    expect(workerCards.find((card) => card.type === 'perfil-cliente')).toBeFalsy();
+  });
+
+  it('calcula el total de tarjetas basado en la lista generada', () => {
+    jest.spyOn(component, 'webViewCards', 'get').mockReturnValue([
+      { type: 'a' } as any,
+      { type: 'b' } as any,
+      { type: 'c' } as any,
+    ]);
+
+    expect(component.totalCardsCount).toBe(3);
+  });
+
+  it('retorna la clase de layout adecuada según el número de tarjetas', () => {
+    const spy = jest.spyOn(component, 'totalCardsCount', 'get').mockReturnValue(2);
+    expect(component.cardsLayoutClass).toBe('cards-2');
+    spy.mockReturnValue(3);
+    expect(component.cardsLayoutClass).toBe('cards-3');
+    spy.mockReturnValue(4);
+    expect(component.cardsLayoutClass).toBe('cards-multi');
+    spy.mockReturnValue(7);
+    expect(component.cardsLayoutClass).toBe('cards-default');
+    spy.mockRestore();
+  });
+
+  it('trackByProductoId utiliza el identificador del producto', () => {
+    const producto = { productoId: 42 } as ProductoVendido;
+    expect(component.trackByProductoId(0, producto)).toBe(42);
+  });
+
+  it('obtiene la imagen del producto usando el helper seguro', () => {
+    const producto = { productoId: 5, imagen: 'abc' } as ProductoVendido;
+    const safeSpy = jest.spyOn(imageUtils, 'getSafeImageSrc').mockReturnValue('safe');
+
+    expect(component.getProductImageSrc(producto)).toBe('safe');
+    expect(safeSpy).toHaveBeenCalledWith('abc', 5);
+  });
+
+  it('obtiene la imagen por índice ajustando el valor inicial', () => {
+    const producto = { productoId: 1, imagen: 'img' } as ProductoVendido;
+    const safeSpy = jest.spyOn(imageUtils, 'getSafeImageSrc').mockReturnValue('safe-index');
+
+    expect(component.getProductImageSrcByIndex(producto, 0)).toBe('safe-index');
+    expect(safeSpy).toHaveBeenCalledWith('img', 1);
+  });
+
+  it('aplica fallback en caso de error de imagen para recursos dinámicos', () => {
+    const img = document.createElement('img');
+    img.src = 'https://example.com/dynamic.png';
+    const event = { target: img } as unknown as Event;
+
+    component.onProductImageError(event);
+
+    expect(img.src).toContain('assets/img/logo2.webp');
+    expect(img.classList.contains('fallback-logo')).toBe(true);
+  });
+
+  it('no aplica fallback para imágenes estáticas reales del proyecto', () => {
+    const img = document.createElement('img');
+    img.src = 'https://example.com/carousel-1.webp';
+    const event = { target: img } as unknown as Event;
+
+    component.onProductImageError(event);
+
+    expect(img.src).toContain('carousel-1.webp');
+    expect(img.classList.contains('fallback-logo')).toBe(false);
+  });
+
+  it('carga productos populares correctamente cuando el backend responde con datos', () => {
+    const productos: ProductoVendido[] = [
+      { productoId: 1, imagen: 'img', nombreProducto: 'Arepa' } as ProductoVendido,
+    ];
+    telemetryStub.getProductosPopulares.mockReturnValue(
+      of({ code: 200, data: { productosPopulares: productos }, message: 'ok' }),
+    );
+    const detectSpy = jest.spyOn((component as any).cdr, 'detectChanges');
+
+    component.loadProductosPopulares();
+
+    expect(telemetryStub.getProductosPopulares).toHaveBeenCalledWith({
+      limit: 4,
+      periodo: 'historico',
+    });
+    expect(component.productosPopulares).toEqual(productos);
+    expect(component.errorProductos).toBe(false);
+    expect(component.loadingProductos).toBe(false);
+    expect(detectSpy).toHaveBeenCalled();
+  });
+
+  it('marca error cuando el backend no retorna datos válidos', () => {
+    telemetryStub.getProductosPopulares.mockReturnValue(
+      of({ code: 500, message: 'fail' } as any),
+    );
+    const detectSpy = jest.spyOn((component as any).cdr, 'detectChanges');
+
+    component.loadProductosPopulares();
+
+    expect(component.errorProductos).toBe(true);
+    expect(component.loadingProductos).toBe(false);
+    expect(detectSpy).toHaveBeenCalled();
+  });
+
+  it('maneja errores al cargar productos populares', () => {
+    telemetryStub.getProductosPopulares.mockReturnValue(
+      throwError(() => new Error('network error')),
+    );
+    const detectSpy = jest.spyOn((component as any).cdr, 'detectChanges');
+
+    component.loadProductosPopulares();
+
+    expect(component.errorProductos).toBe(true);
+    expect(component.loadingProductos).toBe(false);
+    expect(detectSpy).toHaveBeenCalled();
+  });
+
+  it('detecta dispositivos móviles y actualiza cuando cambia el viewport', () => {
+    (component as any).platformId = 'browser';
+    const originalInnerWidth = window.innerWidth;
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(window, 'innerWidth', { value: 980, configurable: true });
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 10.0)',
+      configurable: true,
+    });
+    const detectSpy = jest.spyOn((component as any).cdr, 'detectChanges');
+
+    (component as any).detectMobileDevice();
+    expect(component.isMobile).toBe(true);
+
+    Object.defineProperty(window, 'innerWidth', { value: 1200, configurable: true });
+    window.dispatchEvent(new Event('resize'));
+    expect(component.isMobile).toBe(false);
+    expect(detectSpy).toHaveBeenCalledTimes(1);
+
+    window.dispatchEvent(new Event('resize'));
+    expect(detectSpy).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, configurable: true });
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+
+  it('limpia los recursos al destruir el componente', () => {
+    (component as any).platformId = 'browser';
+    component.isWebView = true;
+    const clearSpy = jest.spyOn(imageUtils, 'clearBlobUrlCache').mockImplementation(() => {});
+    const footerMock = { disconnect: jest.fn() };
+    (component as any).footerObserver = footerMock;
+    const authSub = new BehaviorSubject<boolean>(false).subscribe();
+    (component as any).authSub = authSub;
+
+    component.ngOnDestroy();
+
+    expect(clearSpy).toHaveBeenCalled();
+    expect(document.body.classList.contains('is-native')).toBe(false);
+    expect(footerMock.disconnect).toHaveBeenCalled();
+    expect(authSub.closed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- extend the HomeComponent spec to exercise card getters, layout logic, product image fallbacks, telemetry loading paths, and cleanup logic
- stub TelemetryService responses and reuse shared image utilities to cover success and error branches while verifying device detection behaviour

## Testing
- npm test -- --runTestsByPath src/app/modules/public/home/home.component.spec.ts *(fails: jest binary unavailable because packages cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c81147dc8325b4c2bae33320c0e6